### PR TITLE
Rename `code-collaboration` to `git-protocol`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,8 +26,8 @@ logoalt: 18F logo
 # Navigation
 # List links that should appear in the site sidebar here
 navigation:
-- text: Collaborating on Code
-  url: code-collaboration/
+- text: Git Protocol
+  url: git-protocol/
   internal: true
 - text: Code Review
   url: code-review/

--- a/pages/git-protocol.md
+++ b/pages/git-protocol.md
@@ -1,19 +1,17 @@
 ---
-permalink: /code-collaboration/
-title: Collaborating on Code
+permalink: /git-protocol/
+title: Git Protocol
 ---
 
 **WORK IN PROGRESS**
 Initial content borrowed from:
 https://github.com/thoughtbot/guides/blob/master/protocol/git/README.md
 
-Collaborating on Code
-=====================
+## Collaborating on Code
 
 A guide for programming within version control.
 
-Maintain a Repo on GitHub
--------------------------
+### Maintain a Repo on GitHub
 
 * Make all new repos public by default unless there's a compelling reason not
   to.
@@ -26,8 +24,7 @@ Maintain a Repo on GitHub
 
 [pull request]: https://help.github.com/articles/using-pull-requests/
 
-Write a Feature
----------------
+### Write a Feature
 
 Create a local feature branch based off master or your main development branch.
 
@@ -58,11 +55,6 @@ Write a [good commit message]. Example format:
 
     http://project.management-system.com/ticket/123
 
-If you've created more than one commit, use a rebase to squash them into
-cohesive commits with good messages:
-
-    git rebase -i origin/master
-
 Share your branch.
 
     git push origin <branch-name>
@@ -76,12 +68,11 @@ to be reviewed.
 [good commit message]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [GitHub pull request]: https://help.github.com/articles/using-pull-requests/
 
-Review Code
------------
+### Review Code
 
-A team member other than the author reviews the pull request. They follow
-[Code Review guidelines](https://pages.18f.gov/development-guide/code-review/)
-to avoid miscommunication.
+A team member other than the author reviews the pull request. They follow [Code
+Review guidelines](https://pages.18f.gov/development-guide/code-review/) to
+avoid miscommunication.
 
 They make comments and ask questions directly on lines of code in the GitHub
 web interface or in the project's chat room.
@@ -93,21 +84,8 @@ Repeat until all comments have been addressed. The reviewer then merges the PR
 and deletes the branch.
 
 [Code Review guideline]: {{ site.baseurl }}/code-review/
-Merge
------
 
-Rebase interactively. Squash commits like "Fix whitespace" into one or a
-small number of valuable commit(s). Edit commit messages to reveal intent. Run
-tests.
-
-    git fetch origin
-    git rebase -i origin/master
-
-Force push your branch. This allows GitHub to automatically close your pull
-request and mark it as merged when your commit(s) are pushed to master. It also
- makes it possible to [find the pull request] that brought in your changes.
-
-    git push --force origin <branch-name>
+### Merge
 
 View a list of new commits. View changed files. Merge branch into master.
 


### PR DESCRIPTION
* Makes the contents of the guide more intuitive
* Also removed some obviously non-applicable sections (eg: force pushing
  / rebasing are not common at 18F)