### PR TITLE
Commit messages should include implications

### DIFF
--- a/git_protocol/README.md
+++ b/git_protocol/README.md
@@ -46,7 +46,7 @@ When you've staged the changes, commit them.
     git status
     git commit --verbose
 
-Write a [good commit message]. Example format:
+Write a [good commit message], which should contain all the necessary context around why the change is being made, any security or developer workflow implications, etc. Example format:
 
     Present-tense summary under 50 characters
 


### PR DESCRIPTION
As I was re-writing a part of cloud.gov's FedRAMP documentation, I saw that [NIST 800-53 r4 SA-10.d](https://web.nvd.nist.gov/view/800-53/Rev4/control?controlName=SA-10) requires that we

> Document approved changes to the system, component, or service and the potential security impacts of such changes

I could include this in cloud.gov documentation, but figured it was broadly-applicable enough to put in the 18F-wide guide.

/cc @brittag 