### PR TITLE
Update Style/FrozenStringLiteralComment

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -135,7 +135,8 @@ Style/ExtraSpacing:
   ForceEqualSignAlignment: false
 
 Style/FrozenStringLiteralComment:
-  StyleGuide: Check for the comment `# frozen_string_literal: true` to the top
+  StyleGuide: >-
+    Check for the comment `# frozen_string_literal: true` to the top
     of files. This will help with upgrading to Ruby 3.0.
   Enabled: false
 


### PR DESCRIPTION
This PR is an update to the comment in the Style/FrozenStringLiteralComment spec.

The colon was causing problems with hound integration. I moved the comment into a comment block and no longer had issues!

cc @jessieay 