### PR TITLE
Remove unnecessary bundle exec

### DIFF
--- a/accessibility_scanning/README.md
+++ b/accessibility_scanning/README.md
@@ -32,7 +32,7 @@ dependencies:
 test:
   post:
     - bundle exec jekyll serve --detach
-    - bundle exec accesslint-ci scan http://localhost:4000
+    - accesslint-ci scan http://localhost:4000
 ```
 
 The `ACCESSLINT_MASTER_BRANCH` should be set to the branch that PRs are being made to. If it is not set, it will default to `master`. For 18F repos, this will generally be `dev` or `development`.


### PR DESCRIPTION
I was following your instructions for accesslint and noticed an error. Since you're not installing accesslint-ci with bundler, you can't use `bundle exec` when executing it:
```
bundle exec accesslint-ci scan http://localhost:4000
bundler: failed to load command: accesslint-ci (/opt/circleci/.rvm/gems/ruby-2.3.1/bin/accesslint-ci)
Gem::LoadError: accesslint-ci is not part of the bundle. Add it to Gemfile.
  /opt/circleci/.rvm/gems/ruby-2.3.1/gems/bundler-1.14.6/lib/bundler/rubygems_integration.rb:351:in `block (2 levels) in replace_gem'
  /opt/circleci/.rvm/gems/ruby-2.3.1/bin/accesslint-ci:22:in `<top (required)>'

bundle exec accesslint-ci scan http://localhost:4000 returned exit code 1
```
This PR fixes just by dropping the `bundle exec`.