### PR TITLE
Propose using classifications on guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
-## 18F Development Guide
+# 18F Development Guide
 
-A set of guidelines and best practices for an awesome engineering team
+A set of guidelines and best practices for an awesome engineering team.
+
+
+## How we classify best practices
+
+These documents are structured by topic; under each, we include “Standards”,
+“Defaults”, and “Suggestions”.
+
+**Standards** are practices that have a strong consensus across 18F; they
+should generally be followed to ease the ATO process and make on-boarding
+simpler.
+
+**Defaults** are safe selections that tend to be used by a large number of our
+projects; you may find yourself with a better or more tailored solution,
+however.
+
+**Suggestions** contain examples that have worked well on a project or two;
+they're not widely used enough to be defaults, but are worth considering.
+
+_Note: we've adopted the above classifications but not all the topics have been
+updated to use them. Please submit a pull request to recommend particular
+classification for discussion._
+
+
+## Topics
 
 * [Third-Party Integrations](/integrations)
 * [Workflow Best Practices](/workflow)
@@ -11,14 +35,14 @@ A set of guidelines and best practices for an awesome engineering team
 * [Continuous Deployment with Autopilot Guide](/continuous_deployment)
 * [Datastore Selection Guidance](/datastore_selection)
 
-### Language Guides
+## Language Guides
 
 * [Language Selection Guidance](/language_selection)
 * [Node](/nodejs)
 * [Python](/python)
 * [Ruby](/ruby)
 
-### Public domain
+## Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in
 [CONTRIBUTING](CONTRIBUTING.md):


### PR DESCRIPTION
I want to propose we use specific classifications for our best practices and guidelines. I've used these in the [nodejs guide](https://github.com/18F/development-guide/tree/master/nodejs#nodejavascript-development-guide). They are ranked from most consensus to least:

1. Standards
1. Defaults
1. Suggestions

In other words, if something is a Standard at 18F, it is a practice where there is strong consensus within 18F that it is a _best_ practice.

### Why do these matter?

Once we start defining how much _consensus_ we have on best practices, we can start incorporating them in automation tools like [18f-cli](https://github.com/18F/18f-cli). This helps us prioritize what would actually help people.

For example, if there are many opinions on [shells](https://en.wikipedia.org/wiki/Shell_(computing)) it probably does not make sense to automate in say, the [laptop](https://github.com/18f/laptop) script. If you do automate something where there is no/little consensus, then you risk supporting many different opinions which is an inefficient use of time and effort.