### PR TITLE
Copy and tweak CircleCI config from TTS handbook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+version: 2.1
+jobs:
+  build:
+    working_directory: ~/development-guide
+    docker:
+      - image: circleci/ruby:2.6.1
+    environment:
+      # fix encoding
+      - LANG: C.UTF-8
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v2-dependencies-{{ checksum "Gemfile.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - v2-dependencies-
+
+      - run:
+          name: install dependencies
+          command: bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
+
+      - run:
+          name: checking internal links
+          # grep for pages with markdown links to local pages (links with "(/").
+          # if found, fail build with error message (grep returns the opposite
+          # exit code from what we’re hoping for, so the '!' negates the
+          # expression to pass/fail the build as expected).
+          command: |
+            ! (grep -Erl "\(/|href=['\"]/" _pages && echo "ERROR: Internal links must be prefixed with {{site.baseurl}} to work correctly with Federalist Previews. Fix the above pages.")
+      - run:
+          name: build site
+          command: bundle exec jekyll build
+
+      - run:
+          name: htmlproofer
+          command: bundle exec htmlproofer ./_site htmlproofer --disable-external


### PR DESCRIPTION
Branch name is a misnomer – this addresses remaining items on #95 by incorporating the [CircleCI config from the TTS handbook](https://github.com/18F/handbook/blob/master/.circleci/config.yml).