### PR TITLE
Fix CircleCI driven builds and false build failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,12 +28,13 @@ jobs:
 
       - run:
           name: checking internal links
-          # grep for pages with markdown links to local pages (links with "(/").
+          # grep for pages with markdown links to local pages (links with "(/"),
+          # ignoring any binary files.
           # if found, fail build with error message (grep returns the opposite
           # exit code from what we’re hoping for, so the '!' negates the
           # expression to pass/fail the build as expected).
           command: |
-            ! (grep -Erl "\(/|href=['\"]/" _pages && echo "ERROR: Internal links must be prefixed with {{site.baseurl}} to work correctly with Federalist Previews. Fix the above pages.")
+            ! (grep -IErl "\(/|href=['\"]/" _pages && echo "ERROR: Internal links must be prefixed with {{site.baseurl}} to work correctly with Federalist Previews. Fix the above pages.")
       - run:
           name: build site
           command: bundle exec jekyll build

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ group :jekyll_plugins do
   gem 'jekyll_pages_api_search'
   gem 'jemoji', '>= 0.9.0'
 end
+
+group :development do
+  gem 'html-proofer'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     eventmachine (1.2.7)
     ffi (1.12.2)
     forwardable-extended (2.6.0)
@@ -27,6 +29,14 @@ GEM
     html-pipeline (2.12.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (3.15.1)
+      addressable (~> 2.3)
+      mercenary (~> 0.3)
+      nokogumbo (~> 2.0)
+      parallel (~> 1.3)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     htmlentities (4.3.4)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
@@ -68,9 +78,13 @@ GEM
     minitest (5.14.0)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
+    nokogumbo (2.0.2)
+      nokogiri (~> 1.8, >= 1.8.4)
+    parallel (1.19.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.3)
+    rainbow (3.0.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -82,13 +96,17 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     thread_safe (0.3.6)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
+    yell (2.2.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  html-proofer
   jekyll_pages_api_search
   jemoji (>= 0.9.0)
   uswds-jekyll!

--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ styles:
   - /assets/css/styles.css
 
 exclude:
+  - vendor
   - CONTRIBUTING.md
   - Gemfile
   - Gemfile.lock
@@ -11,6 +12,8 @@ exclude:
   - README.md
   - go
   - copy-template
+  - Dockerfile
+  - docker-compose.yml
 
 theme: uswds-jekyll
 


### PR DESCRIPTION
This PR should correct the false build failures from CircleCI.

* The CircleCI config we reused from the TTS handbook will erroneously flag .pngs, .pdfs as not having `{{site.baseurl}}`. For now, just ignore binary files in the check and defer a decision as to whether or not those binary files really should live outside of `_pages`.
* Build process is also a little different than local – ignore vendor tree.
* Add html-proofer as a dependency.

