### PR TITLE
Ignore binary files in site.baseurl check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,15 +26,15 @@ jobs:
             - ./vendor/bundle
           key: v2-dependencies-{{ checksum "Gemfile.lock" }}
 
-      # Temporarily disable
-      #- run:
-          #name: checking internal links
-          # grep for pages with markdown links to local pages (links with "(/").
+      - run:
+          name: checking internal links
+          # grep for pages with markdown links to local pages (links with "(/"),
+          # ignoring any binary files.
           # if found, fail build with error message (grep returns the opposite
           # exit code from what we’re hoping for, so the '!' negates the
           # expression to pass/fail the build as expected).
-          #command: |
-          #  ! (grep -Erl "\(/|href=['\"]/" _pages && echo "ERROR: Internal links must be prefixed with {{site.baseurl}} to work correctly with Federalist Previews. Fix the above pages.")
+          command: |
+            ! (grep -IErl "\(/|href=['\"]/" _pages && echo "ERROR: Internal links must be prefixed with {{site.baseurl}} to work correctly with Federalist Previews. Fix the above pages.")
       - run:
           name: build site
           command: bundle exec jekyll build


### PR DESCRIPTION
The CircleCI config we reused from the TTS handbook will erroneously flag .pngs, .pdfs as not having {{site.baseurl}}. 

For now, just ignore binary files in the check, as it's convenient in some cases to have associated images, PDFs nested under a subsection folder. 