### PR TITLE
Remove duplicate link for project setup

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -19,7 +19,6 @@ A set of guidelines and best practices for an awesome engineering team
 * [Development Environments]({{site.baseurl}}/development-environments)
 * [Incident Reports]({{site.baseurl}}/incident-reports)
 * [Polls]({{site.baseurl}}/polls)
-* [Project Setup]({{site.baseurl}}/project-setup)
 * [Tech Leads]({{site.baseurl}}/tech-leads)
 
 ### Language Guides


### PR DESCRIPTION
"/project-setup" was in the list twice, so I removed the second instance.