### PR TITLE
Update navigation.yml link

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -55,4 +55,4 @@ security:
   - text: Content Security Policy (CSP)
     href: /security/content-security-policy/
   - text: Output Encoding
-    href: /security/output_encoding/
+    href: /security/output-encoding/


### PR DESCRIPTION
https://engineering.18f.gov/security/ links to https://engineering.18f.gov/security/output_encoding/ when it should be https://engineering.18f.gov/security/output-encoding/