### PR TITLE
Enable htmlproofer and fix errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,6 @@ jobs:
           name: build site
           command: bundle exec jekyll build
 
-      # Temporarily disable
-      #- run:
-          #name: htmlproofer
-          #command: bundle exec htmlproofer ./_site htmlproofer --disable-external
+      - run:
+          name: htmlproofer
+          command: bundle exec htmlproofer ./_site htmlproofer --disable-external

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gem 'uswds-jekyll', :git => 'https://github.com/18F/uswds-jekyll.git'
 
+gem 'html-proofer'
+
 group :jekyll_plugins do
   gem 'jekyll_pages_api_search'
   gem 'jemoji', '>= 0.11.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     eventmachine (1.2.7)
     ffi (1.12.2)
     forwardable-extended (2.6.0)
@@ -27,6 +29,14 @@ GEM
     html-pipeline (2.12.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (3.15.1)
+      addressable (~> 2.3)
+      mercenary (~> 0.3)
+      nokogumbo (~> 2.0)
+      parallel (~> 1.3)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     htmlentities (4.3.4)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
@@ -68,9 +78,13 @@ GEM
     minitest (5.14.0)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
+    nokogumbo (2.0.2)
+      nokogiri (~> 1.8, >= 1.8.4)
+    parallel (1.19.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.3)
+    rainbow (3.0.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -82,13 +96,17 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     thread_safe (0.3.6)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
+    yell (2.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  html-proofer
   jekyll_pages_api_search
   jemoji (>= 0.11.1)
   uswds-jekyll!

--- a/_includes/components/footer--medium.html
+++ b/_includes/components/footer--medium.html
@@ -11,7 +11,7 @@
 
   {% if footer.top %}
     <div class="usa-grid usa-footer-return-to-top">
-      <a href="{{ footer.top.href | default: '#' }}">{{ footer.top.text | default: 'Return to top' }}</a>
+      <a href="{{ footer.top.href | default: '#' }}" data-proofer-ignore>{{ footer.top.text | default: 'Return to top' }}</a>
     </div>
   {% endif %}
 

--- a/_pages/css/architecture.md
+++ b/_pages/css/architecture.md
@@ -19,8 +19,7 @@ to keep the specificity trend in an upwards curve as you move down in the file
 
 - Start with an elements file for all tag rules (a, h1-h5, p, \*, html, body).
 - Create component files for each structural element, such as buttons, navs,
-  etc. These are mainly class-based and use [BEM] or another [naming
-  scheme](#css-naming).
+  etc. These are mainly class-based and use [BEM] or another naming scheme.
 - Create more specific structure with modules. For instance, if the logo image
   and text needs very specific treatment, use a module.
   - Build modules from components through mixins, extends, and HTML.

--- a/_pages/css/naming.md
+++ b/_pages/css/naming.md
@@ -98,7 +98,7 @@ sidenav: css
 ## Naming Methodologies
 
 When it comes to naming, the most important thing is consistency. The
-recommended way to do this is using an existing methodology like [BEM](#BEM),
+recommended way to do this is using an existing methodology like [BEM](#bem),
 or use a custom one that’s clearly defined.
 
 ### BEM

--- a/_pages/incident-reports.md
+++ b/_pages/incident-reports.md
@@ -48,7 +48,7 @@ Don't make folks search for the information.
 
 ## Examples
 * [C2](./C2/c2-outage-report-2016-08-10.pdf)
-* [Cloud.gov](./cloud_gov)
+* [Cloud.gov](./cloud-gov)
 
 ## Additional resources
 * John Allspaw's [introduction](https://codeascraft.com/2012/05/22/blameless-postmortems/)

--- a/_pages/tech-leads.md
+++ b/_pages/tech-leads.md
@@ -57,7 +57,7 @@ may also require ad-hoc scheduling.
 
 Reviewing project-specific practices enables leads to bring to your team their
 experience and knowledge of other 18F projects. These reviews can be scoped as
-widely (see our [architecture reviews](../architecture_reviews/)) or narrow as
+widely (see our [architecture reviews](../architecture-reviews/)) or narrow as
 you need, depending on your situation. We strongly encourage you to engage
 with technical leads as early as possible, when they can help you avoid or
 solve the kinds of problems that will be harder with time. Leads may suggest


### PR DESCRIPTION
This PR adds `htmlproofer` back to the Gemfile and re-enables the CircleCI test step. It also fixes the errors. The biggest source of errors was the link to the top of the page in the shared footer. I fixed that one by adding a `data-proofer-ignore` attribute to the link, which causes htmlproofer to skip it. The other fixes were one link that no longer exists, a capitalization issue, and switching some underscores to dashes.

Closes #117 