### PR TITLE
Updates to architecture reviews

### DIFF
--- a/_pages/architecture-reviews.md
+++ b/_pages/architecture-reviews.md
@@ -1,15 +1,16 @@
 ---
 title: Architecture Reviews
 ---
+
 # Architecture Reviews
 
-18F has the pleasure of employing a plethora of truly great software
-developers. Unfortunately, our project-focus tends to silo our engineers from
-each other. Rather than wait for knowledge to naturally diffuse through team
-changes, we can kick-start transfer by highlighting some of the more
-interesting design decisions from existing projects.
+Though we pride ourselves on our [transparent and remote-friendly
+workplace](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/),
+our project focus tends to silo engineers from each other. We can kick-start
+knowledge transfer by highlighting some of the more interesting design
+decisions from existing projects.
 
 ## Projects
 
-* [DATA Act Pilot: Simplicity is Key]({{site.baseurl}}/architecture-reviews/data-act-pilot)
-* [Micro-purchase: Do one thing well]({{site.baseurl}}/architecture-reviews/micro-purchase)
+- [DATA Act Pilot: Simplicity is Key]({{site.baseurl}}/architecture-reviews/data-act-pilot) (2016)
+- [Micro-purchase: Do one thing well]({{site.baseurl}}/architecture-reviews/micro-purchase) (2016)


### PR DESCRIPTION
Partially addresses #124 

Since the architecture reviews aren't updated, but snapshots in time, add their original publication year to provide context for their guidance.