### PR TITLE
Revert "Remove front-end disciplines page"

### DIFF
--- a/_pages/frontend.md
+++ b/_pages/frontend.md
@@ -1,0 +1,37 @@
+---
+title: Front-End Disciplines
+---
+# Front-End Disciplines
+
+## Related topics
+* [CSS]({{site.baseurl}}/css)
+* [JavaScript]({{site.baseurl}}/javascript)
+* [Security]({{site.baseurl}}/security)
+
+## What is front end?
+
+The Front-End Guild did a series of exercises to determine the
+fundamental differences between the front-end design and front-end
+developer roles at 18F. Using [some of our own research
+methods](https://methods.18f.gov), the Front-End Guild came up with
+the following recommendations on knowing the difference between the
+two disciplines:
+
+**Front-end designers** design, write, and implement the
+presentational code base for websites and applications. They should
+have a clear understanding of design fundamentals and systems, such
+as interface style guides, responsive design, grid systems, front-end
+frameworks, and accessibility best practices. Front-end designers
+should feel comfortable creating and implementing design systems
+using semantic HTML5, CSS/Sass and be able to assist in debugging
+this aspect of the code base.
+
+**Front-end developers** architect, write, and implement the
+functional code base for websites and applications. They should have
+a clear understanding of client-side render and response, such as
+HTTP methods, API consumption, the browser loading/rendering
+pipeline, and accessibility best practices. Front-end developers
+should feel comfortable developing and implementing client-side
+interactions and frameworks using semantic HTML5 and JavaScript, and
+should be able to help with debugging, testing, and performance
+optimization of the code base.

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -30,6 +30,7 @@ _Note: we've adopted the above classifications but not all the topics have been
 updated to use them. Please submit a pull request to recommend particular
 classification for discussion._
 
+* [Front-End Disciplines]({{site.baseurl}}/frontend)
 * [Third-Party Integrations]({{site.baseurl}}/integrations)
 * [Workflow Best Practices]({{site.baseurl}}/workflow)
 * [Project Setup]({{site.baseurl}}/project-setup)


### PR DESCRIPTION
Resolves https://github.com/18F/development-guide/issues/151 by reverting #140 

Need to reconsider the removal of the frontend disciplines page:
* [18/page-redirects](https://github.com/18F/pages-redirects) was set up to "permanently" redirect `frontend.18f.gov` to `engineering.18f.gov/frontend/`
* removal was driven by outdated content about disciplines on that page and not information architecture (i.e., probably best to consider expanding hierarchy to frontend/backend/mobile/etc., rather than just the language guidance)
