### PR TITLE
Remove h1 headings

### DIFF
--- a/_pages/accessibility-scanning.md
+++ b/_pages/accessibility-scanning.md
@@ -1,6 +1,7 @@
 ---
-title: Accessibility Scanning using AccessLint
+title: Accessibility Scanning
 ---
+
 ## Accessibility Scanning using AccessLint
 
 [AccessLintCI](https://github.com/accesslint/accesslint-ci) is an automated accessibility scanning tool. It is configured with CircleCI (Travis and Jenkins support pending) to leave comments on Pull Requests stating potential accessibility problems with the committed code.

--- a/_pages/architecture-reviews.md
+++ b/_pages/architecture-reviews.md
@@ -2,8 +2,6 @@
 title: Architecture Reviews
 ---
 
-# Architecture Reviews
-
 Though we pride ourselves on our [transparent and remote-friendly
 workplace](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/),
 our project focus tends to silo engineers from each other. We can kick-start

--- a/_pages/architecture-reviews/data-act-pilot.md
+++ b/_pages/architecture-reviews/data-act-pilot.md
@@ -1,7 +1,6 @@
 ---
 title: 'DATA Act Pilot: Simplicity is Key'
 ---
-# DATA Act Pilot: Simplicity is Key
 
 ## TL;DR
 

--- a/_pages/architecture-reviews/micro-purchase.md
+++ b/_pages/architecture-reviews/micro-purchase.md
@@ -1,7 +1,6 @@
 ---
 title: 'Micro-purchase: Do one thing well'
 ---
-# Micro-purchase: Do one thing well
 
 ## TL;DR
 * Use many, focused objects for ease of testing

--- a/_pages/code-review.md
+++ b/_pages/code-review.md
@@ -1,7 +1,7 @@
 ---
 title: Code Review
 ---
-# Code Review
+
 A friendly guide for reviewing code — and not each other — at 18f.
 
 _Forked from the excellent Consumer Financial Protection Bureau

--- a/_pages/continuous-deployment.md
+++ b/_pages/continuous-deployment.md
@@ -1,7 +1,6 @@
 ---
 title: Continuous Deployment
 ---
-# Continuous Deployment
 
 ## Pre-requisites
 

--- a/_pages/css.md
+++ b/_pages/css.md
@@ -3,7 +3,6 @@ title: CSS
 sidenav: css
 ---
 
-# CSS
 The purpose of the CSS coding styleguide is to create consistent CSS or
 preprocessor CSS code across 18F. The styleguide should be treated as a guide
 &mdash; rules can be modified according to project needs.

--- a/_pages/css/architecture.md
+++ b/_pages/css/architecture.md
@@ -2,7 +2,7 @@
 title: Architecture
 sidenav: css
 ---
-# Architecture
+
 A site's architecture should be based on its goals and purposes. This means the
 guidance here should be adapted to different sites and situations.
 

--- a/_pages/css/documentation.md
+++ b/_pages/css/documentation.md
@@ -2,7 +2,7 @@
 title: Documentation
 sidenav: css
 ---
-# Documentation
+
 ## Sass Comments
 Be intentional when you use `//` (silent comments) versus `/* */`
 (which are preserved in the CSS output). When in doubt, use `//`.

--- a/_pages/css/formatting.md
+++ b/_pages/css/formatting.md
@@ -3,8 +3,6 @@ title: Formatting
 sidenav: css
 ---
 
-# Formatting
-
 We recommend using [Prettier](https://prettier.io), and enabling it in your
 editor by default. Prettier is an automatic code formatter that will make your
 code format consistent. This way we don't have to argue over how to format our

--- a/_pages/css/frameworks.md
+++ b/_pages/css/frameworks.md
@@ -2,7 +2,6 @@
 title: Frameworks
 sidenav: css
 ---
-# Frameworks
 
 18F currently recommends using the [U.S. Web Design System](https://github.com/uswds/uswds) as it is specifically designed to help build fast, accessible, mobile-friendly federal government websites.
 

--- a/_pages/css/inheritance.md
+++ b/_pages/css/inheritance.md
@@ -2,7 +2,7 @@
 title: Inheritance
 sidenav: css
 ---
-# Inheritance
+
 ## Mixins
 - Use mixins for groups of properties that appear together intentionally and
   are used multiple times.

--- a/_pages/css/linting.md
+++ b/_pages/css/linting.md
@@ -2,7 +2,7 @@
 title: Linting
 sidenav: css
 ---
-# Linting
+
 The styleguide provides a method of linting [Sass] code to ensure it conforms
 to the rules in the styleguide. This linting tool will go through all Sass code
 and issue warnings wherever the code differs from the styleguide. We've created

--- a/_pages/css/naming.md
+++ b/_pages/css/naming.md
@@ -2,7 +2,7 @@
 title: Naming
 sidenav: css
 ---
-# Naming
+
 - HTML elements should be in lowercase.
 
   ```scss

--- a/_pages/css/preprocessors.md
+++ b/_pages/css/preprocessors.md
@@ -2,7 +2,7 @@
 title: Preprocessors
 sidenav: css
 ---
-# Preprocessors
+
 The most supported CSS preprocessor at 18F is [Sass](http://sass-lang.com/)
 (SCSS). Using this pre-processor means you'll get supported resources such as
 frameworks, libraries, tutorials, and a comprehensive styleguide as support.

--- a/_pages/css/specificity.md
+++ b/_pages/css/specificity.md
@@ -2,7 +2,7 @@
 title: Specificity
 sidenav: css
 ---
-# Specificity
+
 - IDs should be reserved for JavaScript. Don’t use IDs for styles.
 
   ```scss

--- a/_pages/css/units.md
+++ b/_pages/css/units.md
@@ -2,7 +2,7 @@
 title: Units
 sidenav: css
 ---
-# Units
+
 ## Measurements
 - Use **rem** units for font sizes with a px fallback. This can be done with
   the following mixin:

--- a/_pages/css/variables.md
+++ b/_pages/css/variables.md
@@ -2,7 +2,7 @@
 title: Variables
 sidenav: css
 ---
-# Variables
+
 - Create new variables in the following circumstances:
   - The value is repeated twice
   - The value is likely to be updated at least once

--- a/_pages/datastore-selection.md
+++ b/_pages/datastore-selection.md
@@ -1,7 +1,6 @@
 ---
 title: Datastore Selection Guidance
 ---
-# Datastore Selection Guidance
 
 We're fortunate to have dozens of battle-tested datastores available to us,
 filling many different niches and general use cases. Each has its own

--- a/_pages/development-environments.md
+++ b/_pages/development-environments.md
@@ -1,7 +1,6 @@
 ---
 title: Development Environments
 ---
-# Development Environments
 
 ## Why this guide?
 

--- a/_pages/incident-reports.md
+++ b/_pages/incident-reports.md
@@ -1,7 +1,7 @@
 ---
 title: Incident Reports
 ---
-# Incident Reports
+
 Though we fully expect to write dependable applications, every project will
 experience service disruptions and other significant failings. In all cases,
 we want to learn from our mistakes both within our projects and more broadly.

--- a/_pages/incident-reports/cloud-gov.md
+++ b/_pages/incident-reports/cloud-gov.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud.gov post mortems
 ---
-# Cloud.gov post mortems
+
 Cloud.gov post mortems (including incident response) are hosted at
 https://github.com/18F/cg-postmortems

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -35,7 +35,7 @@ classification for discussion._
 * [Workflow Best Practices]({{site.baseurl}}/workflow)
 * [Project Setup]({{site.baseurl}}/project-setup)
 * [Architecture Reviews]({{site.baseurl}}/architecture-reviews)
-* [Accessibility Scanning using AccessLint]({{site.baseurl}}/accessibility-scanning)
+* [Accessibility Scanning]({{site.baseurl}}/accessibility-scanning)
 * [Feedback Guide]({{site.baseurl}}/people)
 * [Continuous Deployment]({{site.baseurl}}/continuous-deployment)
 * [Datastore Selection Guidance]({{site.baseurl}}/datastore-selection)

--- a/_pages/integrations.md
+++ b/_pages/integrations.md
@@ -2,8 +2,6 @@
 title: Third-Party Integrations
 ---
 
-# Third-Party Integrations
-
 Our software is built on the shoulders of giants. We use several third parties
 to perform continuous monitoring, host our apps, etc.; all should be approved
 on the [GSA IT Standards

--- a/_pages/javascript.md
+++ b/_pages/javascript.md
@@ -3,7 +3,6 @@ title: JavaScript
 sidenav: js
 ---
 
-# JavaScript
 The purpose of the JavaScript coding styleguide is to create and utilize
 consistent JS across 18F. The styleguide should be treated as a guide
 &mdash; rules can be modified according to project needs.

--- a/_pages/javascript/dependencies.md
+++ b/_pages/javascript/dependencies.md
@@ -2,7 +2,7 @@
 title: Dependencies
 sidenav: js
 ---
-# Dependencies
+
 The word "dependency" refers to all of the frameworks, libraries, and other tools that your project relies on. *Dependency management* is the process by which tools are incorporated into your project, removed and updated (for instance, when you need a new version of [jQuery]). Here are the tools that we recommend for managing dependencies:
 
 ## Bower

--- a/_pages/javascript/frameworks.md
+++ b/_pages/javascript/frameworks.md
@@ -3,8 +3,6 @@ title: Frameworks
 sidenav: js
 ---
 
-# Frameworks
-
 When choosing a JavaScript web framework, also consider if vanilla JavaScript would satisfy your project needs. "Vanilla JavaScript" (or "vanilla JS") refers to using just JavaScript and the [Web APIs](https://developer.mozilla.org/en-US/docs/Web/API) provided natively by web browsers. For simpler project, vanilla JavaScript helps avoid overengineering, can reduce security and compliance complexity, and may reduce maintenance costs by making it possible for any JavaScript developer to work on it. However, vanilla JavaScript can be unwieldy in complex applications.
 
 ## React

--- a/_pages/javascript/style.md
+++ b/_pages/javascript/style.md
@@ -3,8 +3,6 @@ title: Style / Linting
 sidenav: js
 ---
 
-# Style / Linting
-
 {%include components/tag-standard.html %}
 We recommend combining [Prettier](https://prettier.io) with the
 [Airbnb JavaScript style guide](https://github.com/airbnb/javascript) plugins

--- a/_pages/language-selection.md
+++ b/_pages/language-selection.md
@@ -1,7 +1,6 @@
 ---
 title: Language Selection Guidance
 ---
-# Language Selection Guidance
 
 Many factors should influence how 18F engineers make technology selections
 for their projects. Here, we discuss recommendations on how to select the

--- a/_pages/nodejs.md
+++ b/_pages/nodejs.md
@@ -1,7 +1,6 @@
 ---
 title: Node.js Development Guide
 ---
-# Node.js Development Guide
 
 ## Related topics
 * [JavaScript]({{site.baseurl}}/javascript)

--- a/_pages/people.md
+++ b/_pages/people.md
@@ -1,7 +1,6 @@
 ---
 title: Feedback Guide
 ---
-# Feedback Guide
 
 Here are some attributes of giving feedback in a highly constructive way that we have learned and used over the years.
 

--- a/_pages/people/2016-Assessment-Guide.md
+++ b/_pages/people/2016-Assessment-Guide.md
@@ -1,7 +1,6 @@
 ---
 title: 18F Engineering 2016 End of Year Assessment Guide
 ---
-# 18F Engineering 2016 End of Year Assessment Guide
 
 18F, as a part of GSA, has a mature [performance management and recognition system](https://insite.gsa.gov/portal/content/500278). 
 This includes an end-of-year performance assessment. 18F Engineering’s goals for the end-of-year assessment are to have 

--- a/_pages/people/2017-Assessment-Guide.md
+++ b/_pages/people/2017-Assessment-Guide.md
@@ -1,7 +1,6 @@
 ---
 title: 18F Engineering 2017 End of Year Assessment Guide
 ---
-# 18F Engineering 2017 End of Year Assessment Guide
 
 18F, as a part of GSA, has a mature [performance management and recognition system](https://insite.gsa.gov/topics/hr-pay-and-leave/employee-performance-management). 
 This includes an end-of-year performance assessment. 18F Engineering’s goals for the end-of-year assessment are to have 

--- a/_pages/project-setup.md
+++ b/_pages/project-setup.md
@@ -2,13 +2,11 @@
 title: Project Setup
 ---
 
-## Project Setup
-
 While the specific setup for each TTS project varies widely, there are certain
 elements that should be present in all source code repositories. This document
 aims to detail those elements and suggest corresponding tools and resources.
 
-### Source code management
+## Source code management
 
 TTS projects use GitHub for source code management, with their repositories
 under a [government-owned
@@ -16,7 +14,7 @@ organization](https://handbook.tts.gsa.gov/github/#organizations).
 
 - [GitHub](https://handbook.tts.gsa.gov/github/) {%include components/tag-standard.html %}
 
-### Repository Checklist
+## Repository Checklist
 
 Below is an aspirational list of configuration and files for a source
 code repository. Not all of these elements will apply to every project (e.g.
@@ -52,7 +50,7 @@ visual regression tests don't make sense for an API).
 1. Integration test setup (e.g., [Selenium](https://www.selenium.dev/) {%include components/tag-suggestion.html %})
 1. Visual regression setup (e.g., [Backstop](https://github.com/garris/BackstopJS) {%include components/tag-suggestion.html %})
 
-### Project Management Tool
+## Project Management Tool
 
 Every project, no matter the size, should use a project management tool to keep
 track of ongoing tasks and to do items. The project management tool should be
@@ -62,7 +60,7 @@ it easily.
 - [GitHub Issues](https://guides.github.com/features/issues/) {%include components/tag-default.html %}
 - [Trello](https://trello.com/) {%include components/tag-suggestion.html %}
 
-### Continuous Integration/Continuous Deployment
+## Continuous Integration/Continuous Deployment
 
 Developers don't always remember to run the test suite. That's why we have
 Continuous Integration services to run the tests automatically after each
@@ -80,7 +78,7 @@ for each pull request.
 - [CircleCI](https://circleci.com/) {%include components/tag-default.html %}
 - [GitHub Actions](https://github.com/features/actions) {%include components/tag-suggestion.html %}
 
-### Code coverage metrics
+## Code coverage metrics
 
 Aim for more than 90% of your source code to be covered by tests; worry if
 coverage drops below 80%. For repositories with multiple programming
@@ -91,7 +89,7 @@ individual components.
 - [Code Climate Quality](https://codeclimate.com/quality/) {%include components/tag-suggestion.html %}
 - [CodeCov](https://codecov.io/) {%include components/tag-suggestion.html %}
 
-### Static analysis for code quality
+## Static analysis for code quality
 
 A good [code review process](../code-review/) is essential to writing good code.
 But certain code problems are difficult for humans to spot. Duplication, for
@@ -102,7 +100,7 @@ Analysis](https://before-you-ship.18f.gov/security/static-analysis/).
 
 - [Code Climate Quality](https://codeclimate.com/quality/) {%include components/tag-suggestion.html %}
 
-### Dependency management
+## Dependency management
 
 Applications require specific versions of programming languages, libraries,
 databases, services, and configuration to execute. A dependency management
@@ -112,7 +110,7 @@ teams to create consistent, reproducible, local development environments.
 - [Docker](https://www.docker.com/why-docker) {%include components/tag-suggestion.html %}<br>
   See our [Docker for development](./docker/) recommendations.
 
-### Deployment infrastructure
+## Deployment infrastructure
 
 Developers needing to deploy their code beyond their local environment should
 use either:

--- a/_pages/project-setup/docker.md
+++ b/_pages/project-setup/docker.md
@@ -1,7 +1,6 @@
 ---
 title: Docker for development
 ---
-# Docker for development
 
 Below we lay out recommendations for using Docker to wrap development
 dependencies. Unfortunately, this is a relatively new space and we don't have

--- a/_pages/python.md
+++ b/_pages/python.md
@@ -1,7 +1,6 @@
 ---
 title: Python Development Guide
 ---
-# Python Development Guide
 
 This is a **WORK IN PROGRESS**. Help us make it better by [submitting an
 issue](https://github.com/18F/development-guide) or joining us in the

--- a/_pages/security.md
+++ b/_pages/security.md
@@ -3,6 +3,4 @@ title: Security
 sidenav: security
 ---
 
-# Security
-
 Security is everybody's responsibility at 18F. There are practices that we should adhere to as much as possible when building websites and this guide contains the ones that front-end designers and developers need to be aware of.

--- a/_pages/security/content-security-policy.md
+++ b/_pages/security/content-security-policy.md
@@ -3,8 +3,6 @@ title: Content Security Policy
 sidenav: security
 ---
 
-# Content Security Policy
-
 ## What is Content Security Policy?
 Content Security Policy (referred to as **CSP** in the rest of this guide) is a security measure designed by the W3C (World Wide Web Consortium) to mitigate the likelihood of Cross-Site Scripting (XSS) attacks and data injection. It is designed to be used in conjunction with other security practices currently recommended for web development.
 

--- a/_pages/security/output-encoding.md
+++ b/_pages/security/output-encoding.md
@@ -3,8 +3,6 @@ title: Output Encoding
 sidenav: security
 ---
 
-# Output Encoding
-
 ## What is cross site scripting (XSS)?
 
 Cross site scripting, or XSS, is a form of attack on a web application which involves executing code on a user's browser. Output encoding is a defense against XSS attacks.

--- a/_pages/workflow.md
+++ b/_pages/workflow.md
@@ -2,8 +2,6 @@
 title: Workflow Best Practices
 ---
 
-# Workflow Best Practices
-
 Project teams may vary, but across 18F engineering we aim for consistency
 around deployments, git etiquette, and similar workflow conventions.
 


### PR DESCRIPTION
As of uswds-jekyll v4.2.0, h1 headings are automatically inserted based on the title frontmatter, reducing duplicative text in the markdown.