### PR TITLE
Initial pass of changing 18F to TTS

### DIFF
--- a/_pages/accessibility-scanning.md
+++ b/_pages/accessibility-scanning.md
@@ -39,7 +39,7 @@ test:
     - accesslint-ci scan http://localhost:4000
 ```
 
-The `ACCESSLINT_MASTER_BRANCH` should be set to the branch that PRs are being made to. If it is not set, it will default to `master`. For 18F repos, this will generally be `dev` or `development`.
+The `ACCESSLINT_MASTER_BRANCH` should be set to the branch that PRs are being made to. If it is not set, it will default to `master`. For TTS repos, this will generally be `dev` or `development`.
 
 ### Accesslint API access
 

--- a/_pages/continuous-deployment.md
+++ b/_pages/continuous-deployment.md
@@ -85,6 +85,6 @@ For an example manifest and manifest-staging see here:
 
 ## Zero Downtime Deploy Options
 - `v3-zdt-push` is an official command, yet is in active development. See https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html
-- `zero-downtime-push` is the popular Autopilot plugin used by a lot of 18F projects and used in both of the above examples. It is now unmaintained and archived though. Does not support buildpacks. If your application successfully deploys to cloud.gov but does not start, which may happen for an application that does not have an adequate test suite, you may have to go into the cf target space and manually delete the "APP_NAME-venerable" application in order to make use of `autopilot` again.
+- `zero-downtime-push` is the popular Autopilot plugin used by a lot of TTS projects and used in both of the above examples. It is now unmaintained and archived though. Does not support buildpacks. If your application successfully deploys to cloud.gov but does not start, which may happen for an application that does not have an adequate test suite, you may have to go into the cf target space and manually delete the "APP_NAME-venerable" application in order to make use of `autopilot` again.
 - `blue-green-deploy` another plugin similar to autopilot. https://github.com/bluemixgaragelondon/cf-blue-green-deploy
 - An official CircleCI / Cloud Foundry Orb is also available at https://circleci.com/orbs/registry/orb/circleci/cloudfoundry

--- a/_pages/css.md
+++ b/_pages/css.md
@@ -4,5 +4,5 @@ sidenav: css
 ---
 
 The purpose of the CSS coding styleguide is to create consistent CSS or
-preprocessor CSS code across 18F. The styleguide should be treated as a guide
+preprocessor CSS code across TTS. The styleguide should be treated as a guide
 &mdash; rules can be modified according to project needs.

--- a/_pages/css/frameworks.md
+++ b/_pages/css/frameworks.md
@@ -3,7 +3,7 @@ title: Frameworks
 sidenav: css
 ---
 
-18F currently recommends using the [U.S. Web Design System](https://github.com/uswds/uswds) as it is specifically designed to help build fast, accessible, mobile-friendly federal government websites.
+TTS recommends using the [U.S. Web Design System](https://github.com/uswds/uswds) as it is specifically designed to help build fast, accessible, mobile-friendly federal government websites.
 
 Sometimes, projects utilize other CSS frameworks such as:
 

--- a/_pages/css/naming.md
+++ b/_pages/css/naming.md
@@ -113,7 +113,7 @@ From [Harry Roberts][mindbemding]:
 > just be a component, something might be a child, or element, of that
 > component, and something might be a variation or modifier of that component.
 
-18F generally recommends using a modified BEM methodology outlined in the next
+TTS generally recommends using a modified BEM methodology outlined in the next
 subsection. However, you might want to use standard BEM when:
 
 * You need a naming scheme that general CSS developers will already be familiar
@@ -151,7 +151,7 @@ Here is an example of BEM in SCSS:
 
 ### Suggested custom methodology
 
-The 18F recommendation for a naming methodology is a modified version of BEM.
+The TTS recommendation for a naming methodology is a modified version of BEM.
 It still uses blocks, sections within blocks and modifiers, but with an
 abbreviated syntax.
 

--- a/_pages/css/preprocessors.md
+++ b/_pages/css/preprocessors.md
@@ -3,11 +3,11 @@ title: Preprocessors
 sidenav: css
 ---
 
-The most supported CSS preprocessor at 18F is [Sass](http://sass-lang.com/)
+The most supported CSS preprocessor at TTS is [Sass](http://sass-lang.com/)
 (SCSS). Using this pre-processor means you'll get supported resources such as
 frameworks, libraries, tutorials, and a comprehensive styleguide as support.
 
-In addition, 18F uses a [`.scss-lint.yml`
+In addition, TTS uses a [`.scss-lint.yml`
 file](https://raw.githubusercontent.com/18F/frontend/18f-pages-staging/.scss-lint.yml)
 to keep our CSS code compliant with our own styleguide.
 

--- a/_pages/datastore-selection.md
+++ b/_pages/datastore-selection.md
@@ -5,7 +5,7 @@ title: Datastore Selection Guidance
 We're fortunate to have dozens of battle-tested datastores available to us,
 filling many different niches and general use cases. Each has its own
 strengths, weaknesses, configuration, backup system, security profile, and
-cognitive overhead. In an effort to make this selection simpler, 18F
+cognitive overhead. In an effort to make this selection simpler, TTS
 engineering **defaults** to using Postgres for the majority of our
 applications. This also allows us to collectively learn best practices around
 security configurations, indexing strategies, and so forth, particularly

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -1,5 +1,5 @@
 ---
-title: 18F Engineering Practices Guide
+title: TTS Engineering Practices Guide
 permalink: /
 ---
 A set of guidelines and best practices for an awesome engineering team
@@ -12,7 +12,7 @@ These documents are structured by topic; under each, we include "Requirement",
 {%include components/tag-requirement.html %} indicates practices that *must* be done for
 regulatory, legal, compliance, or other reasons.
 
-{%include components/tag-standard.html %} signifies practices that have a strong consensus across 18F; they
+{%include components/tag-standard.html %} signifies practices that have a strong consensus across TTS; they
 should generally be followed to ease the ATO process and make on-boarding
 simpler.
 

--- a/_pages/javascript.md
+++ b/_pages/javascript.md
@@ -4,7 +4,7 @@ sidenav: js
 ---
 
 The purpose of the JavaScript coding styleguide is to create and utilize
-consistent JS across 18F. The styleguide should be treated as a guide
+consistent JS across TTS. The styleguide should be treated as a guide
 &mdash; rules can be modified according to project needs.
 
 ## Related topics

--- a/_pages/javascript/dependencies.md
+++ b/_pages/javascript/dependencies.md
@@ -21,7 +21,7 @@ It's not needed and should be phased out and replaced by npm. More information c
   - [jQuery]: `npm install --save jquery`
   - [D3]: `npm install --save d3@v3.5.5` (version 3.5.5)
 
-npm installs its dependencies in the `node_modules` directory. Common conventions dictate that `node_modules` should be excluded from source control by adding it to your project's `.gitignore`, primarily because Node.js-friendly environments (such as 18F's deployment service, [Cloud Foundry], and other such as [Heroku]) recognize the existence of `package.json` and automatically install dependencies as needed.
+npm installs its dependencies in the `node_modules` directory. Common conventions dictate that `node_modules` should be excluded from source control by adding it to your project's `.gitignore`, primarily because Node.js-friendly environments (such as [Cloud Foundry] and [Heroku]) recognize the existence of `package.json` and automatically install dependencies as needed.
 
 ### Install npm
 
@@ -39,11 +39,11 @@ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.6/install.sh | b
 ### Safely installing packages from npm
 While npm is generally a safe environment to install code from, there are certain aspects of the system that are vulnerable to dangerous script execution. Luckily there are steps that can be taken to minimize these risks.
 
-It's recommended that developers at 18F follow these guidelines when installing unknown or new packages.
+It's recommended that developers at TTS follow these guidelines when installing unknown or new packages.
 
 npm allows various hooks to be executed during the install process. These scripts are where potential dangerous scripts can be executed. To limit this it's recommended to:
 
-1. install npm in a manner so sudo is never required. The 18F recommended way of doing this is to [install with nvm](#install-npm).
+1. install npm in a manner so sudo is never required. The TTS recommended way of doing this is to [install with nvm](#install-npm).
 1. check which scripts will be run on install by running `npm show $module scripts`.
   - Each script under `preinstall`, `install`, `postinstall` will be run when installing.
   - Each script under `postuninstall`, `preuninstall`, `uninstall` will be run on uninstall.

--- a/_pages/javascript/style.md
+++ b/_pages/javascript/style.md
@@ -8,7 +8,7 @@ We recommend combining [Prettier](https://prettier.io) with the
 [Airbnb JavaScript style guide](https://github.com/airbnb/javascript) plugins
 for [eslint](https://eslint.org).
 
-Maintaining stylistic consistency across 18F's code helps lower the barrier to
+Maintaining stylistic consistency across TTS' code helps lower the barrier to
 jumping in and helping with or reviewing other projects because we'll all be
 familiar with reading and working with code that looks similar. Having
 consistent rules for styling also removes generally non-productive discussions

--- a/_pages/javascript/style.md
+++ b/_pages/javascript/style.md
@@ -8,7 +8,7 @@ We recommend combining [Prettier](https://prettier.io) with the
 [Airbnb JavaScript style guide](https://github.com/airbnb/javascript) plugins
 for [eslint](https://eslint.org).
 
-Maintaining stylistic consistency across TTS' code helps lower the barrier to
+Maintaining stylistic consistency across TTS code helps lower the barrier to
 jumping in and helping with or reviewing other projects because we'll all be
 familiar with reading and working with code that looks similar. Having
 consistent rules for styling also removes generally non-productive discussions

--- a/_pages/language-selection.md
+++ b/_pages/language-selection.md
@@ -2,7 +2,7 @@
 title: Language Selection Guidance
 ---
 
-Many factors should influence how 18F engineers make technology selections
+Many factors should influence how TTS engineers make technology selections
 for their projects. Here, we discuss recommendations on how to select the
 _language_ used in your projects. This document doesn't offer hard-and-fast
 rules, focusing instead on several language aspects<sup>[1](#aspect)</sup>
@@ -18,7 +18,7 @@ GitHub to suggest changes to these standards.
 
 ## Our strongest languages
 
-18F has historically worked in three **primary** languages: JavaScript,
+TTS has historically worked in three **primary** languages: JavaScript,
 Python, and Ruby. While we certainly have a healthy smattering of other odds
 and ends, these three are our primary strength<sup>[3](#strong)</sup> as
 indicated by data from past projects, engineer skill sets, and billable hours.
@@ -67,7 +67,7 @@ Languages are not all equal<sup>[10](#triple-equal)</sup>. We next consider a
 handful of factors to weigh when selecting a language for a project. In no
 particular order:
 
-* Open source - 18F is a strong proponent of open source; we want our language
+* Open source - TTS is a strong proponent of open source; we want our language
   selection<sup>[11](#select)</sup> to reflect that. We want open APIs, open
   source binaries, and community participation.
 * Domain preference - certain problem domains emphasize particular languages.
@@ -75,9 +75,9 @@ particular order:
   SOAP-heavy specs<sup>[12](#specs)</sup> are more friendly in Java, and Rails
   projects promote CoffeeScript. We want to use the tools appropriate for the
   job.
-* Team familiarity - avoid the bus problem. The more 18F engineers who are
+* Team familiarity - avoid the bus problem. The more TTS engineers who are
   comfortable with a language, the safer<sup>[13](#safe)</sup> it is to use.
-  We want our project to be accessible to many both within 18F and without.
+  We want our project to be accessible to many both within TTS and without.
 * Stability - bleeding edge languages are more risky. If the standard API is
   changing every few months, we aren't going to be able to maintain the
   project. Try to fathom<sup>[14](#fantom)</sup> how this bodes when we're
@@ -86,7 +86,7 @@ particular order:
   or never gained traction. We will be leaning<sup>[15](#lein)</sup> on the
   community for support and potentially to hire contractors and vendors. Less
   active communities make this more difficult.
-* Inclusive communities - 18F promotes welcoming cultures and we want to see
+* Inclusive communities - TTS promotes welcoming cultures and we want to see
   that reflected in our language selection. We want to reward language leaders
   who promote diverse opinions and have open standards processes. We see
   languages led by cabals<sup>[16](#cabal)</sup> as risks.

--- a/_pages/nodejs.md
+++ b/_pages/nodejs.md
@@ -14,7 +14,7 @@ issue](https://github.com/18F/development-guide) or joining us in the
 This document is structured by topic; under each, we include “Standards”,
 “Defaults”, and “Suggestions”.
 
-**Standards** are practices that have a strong consensus across 18F; they
+**Standards** are practices that have a strong consensus across TTS; they
 should generally be followed to ease the ATO process and make on-boarding
 simpler.
 
@@ -112,8 +112,8 @@ We **suggest** using one of the following scaffolds:
 
 Static typing can both make code authors' intent clearer and reduce the number
 of bugs through static analysis. It's also notorious for slowing down the pace
-of prototyping and requiring a great deal of boiler-plate. A significant
-number of 18F projects are using [TypeScript](https://www.typescriptlang.org/)
+of prototyping and requiring a great deal of boiler-plate. Some TTS
+projects are using [TypeScript](https://www.typescriptlang.org/)
 to add static typing, while a handful are testing out
 [Flow](https://flow.org/).
 

--- a/_pages/people.md
+++ b/_pages/people.md
@@ -24,7 +24,7 @@ Giving constructive feedback to a top performer is not nitpicking, it is actuall
 
 ### End of Year Assessment Guides
 
-18F, as a part of GSA, has a mature [performance management and recognition system](https://insite.gsa.gov/portal/content/500278). 
+TTS, as a part of GSA, has a mature [performance management and recognition system](https://insite.gsa.gov/portal/content/500278). 
 This includes an end-of-year performance assessment.
 
 * [2016 Assessment Guide]({{site.baseurl}}/people/2016-Assessment-Guide)

--- a/_pages/project-setup/docker.md
+++ b/_pages/project-setup/docker.md
@@ -14,7 +14,7 @@ Consider your app's production environment. You're likely running on cloud.gov
 (which runs Ubuntu Linux) with specific versions of databases, app language
 (e.g. Go/Node/Python/Ruby), and required libraries (you are [pinning your
 dependencies](https://pages.18f.gov/before-you-ship/infrastructure/pinning-dependencies/),
-right?). Now consider your local environment; if you're an 18F engineer, you
+right?). Now consider your local environment; if you're an TTS engineer, you
 likely have OS X, language version management tools, and an assortment of
 strategies for running databases, worker queues, etc. If you're a designer,
 open source contributor, or working at a partner agency, we should assume even
@@ -50,7 +50,7 @@ both of these problems by allowing us to specify different services,
 dependencies between those services, and specific values for exposed ports,
 mount points, etc. Though it feels more complex at first, we recommend using
 docker-compose even when a single Dockerfile would suffice so that we have a
-consistent tool across 18F engineering. One of the bigger "aha" moments you
+consistent tool across TTS engineering. One of the bigger "aha" moments you
 will encounter is transitioning from thinking of Docker as a VM build script
 (a la `vagrant`) to thinking of it as a way to configure ("orchestrate")
 several, single-purpose containers (i.e. microservices).

--- a/_pages/python.md
+++ b/_pages/python.md
@@ -9,7 +9,7 @@ issue](https://github.com/18F/development-guide) or joining us in the
 This document is structured by topic; under each, we include “Standards”,
 “Defaults”, and “Suggestions”.
 
-**Standards** are practices that have a strong consensus across 18F; they
+**Standards** are practices that have a strong consensus across TTS; they
 should generally be followed to ease the ATO process and make on-boarding
 simpler.
 
@@ -31,9 +31,9 @@ on cloud.gov and incrementally update as new releases are issued.
 
 When using [Django], we **default** to starting with the most recent [Long Term
 Support](https://www.djangoproject.com/download/#supported-versions) release.
-This will give your project the most runway of support after 18F finishes its
-work. If a second LTS becomes available while building the project, upgrade at
-the earliest convenience. Devs that follow will thank you.
+This will give your project the most runway of support. If a second LTS becomes
+available while building the project, upgrade at the earliest convenience. Devs
+that follow will thank you.
 
 Otherwise, our **standard** practice is to use the latest release of our
 libraries when first installing. Security updates (as indicated by GitHub or

--- a/_pages/security.md
+++ b/_pages/security.md
@@ -3,4 +3,4 @@ title: Security
 sidenav: security
 ---
 
-Security is everybody's responsibility at 18F. There are practices that we should adhere to as much as possible when building websites and this guide contains the ones that front-end designers and developers need to be aware of.
+Security is everybody's responsibility at TTS. There are practices that we should adhere to as much as possible when building websites and this guide contains the ones that front-end designers and developers need to be aware of.

--- a/_pages/security/output-encoding.md
+++ b/_pages/security/output-encoding.md
@@ -13,7 +13,7 @@ To get a more extensive understanding of XSS, see [excess xss](https://excess-xs
 
 Protecting from XSS attacks requires developers to consider how data is being displayed on a page. If the data could come from a user's input in any way (including through the site's URL), then correct encoding of the output has to be considered.
 
-Since most web applications at 18F are built through JavaScript or backend frameworks, this guide will go over output encoding issues by those frameworks in addition to plain JavaScript.
+Since most web applications at TTS are built through JavaScript or backend frameworks, this guide will go over output encoding issues by those frameworks in addition to plain JavaScript.
 
 ### Vanilla JavaScript
 

--- a/_pages/workflow.md
+++ b/_pages/workflow.md
@@ -2,7 +2,7 @@
 title: Workflow Best Practices
 ---
 
-Project teams may vary, but across 18F engineering we aim for consistency
+Project teams may vary, but across TTS engineering we aim for consistency
 around deployments, git etiquette, and similar workflow conventions.
 
 ## Continuous Integration & Deployment
@@ -40,7 +40,7 @@ workflows]({{site.baseurl}}/example-workflows).
   version control.
 - Enable [**two-factor
   authentication**](https://help.github.com/articles/about-two-factor-authentication/)
-  for your GitHub account. This is required for all 18F employees.
+  for your GitHub account. This is required for all TTS employees.
 - Default to **public** for new repositories. See our
   [guidelines](https://github.com/18F/open-source-policy/blob/master/practice.md)
   about open source for more detail.


### PR DESCRIPTION
An overdue swap of `18F` for `TTS` in the guide content, since the guide is a product of the TTS Engineering Practice Guild. It is a little imprecise when describing some trends or practices, as
much of the original content was only done with 18F in mind, but it is good enough as a start.