### PR TITLE
Assign header type as "basic" for TTS Handbook consistency

### DIFF
--- a/_data/header.yml
+++ b/_data/header.yml
@@ -8,6 +8,8 @@
 
 usa_banner: true
 
+type: basic
+
 #primary:
 #  # this is a key into _data/navigation.yml
 #  links: primary


### PR DESCRIPTION
This pull request assigns a missing `type` value for the header data.

Without a type, the base `uswds-jekyll` theme will not render a wrapping container element:

https://github.com/18F/uswds-jekyll/blob/472991d/_includes/components/header.html#L3-L9

This is also consistent with the TTS Handbook.

URL: https://handbook.tts.gsa.gov/
Code: https://github.com/18F/handbook/blob/3875342/_data/header.yml#L2

**Screenshots:**

Before|After
---|---
![Before screenshot](https://user-images.githubusercontent.com/1779930/86159945-16b74300-bad9-11ea-95a5-4eb4ea26b40f.png)|![After screenshot](https://user-images.githubusercontent.com/1779930/86159952-17e87000-bad9-11ea-9911-6c4dff3442ff.png)

The text wrapping occurs because the USWDS basic header assigns a width of `10%` on the logo container. This appears to have been increased to `33%` as of USWDS v2 ([before](https://v1.designsystem.digital.gov/components/headers/basic/), [after](https://designsystem.digital.gov/components/headers/basic/)), which could be explored as a separate task.