### PR TITLE
Add PrivateEye to mark internal URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,11 @@ markdown: kramdown
 sass:
   style: compressed
 
+scripts:
+  - /assets/uswds/js/uswds.min.js
+  - /assets/js/private-eye.js
+  - /assets/js/application.js
+
 # Author/Organization info to be displayed in the templates
 author:
   name: 18F

--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -1,0 +1,17 @@
+document.addEventListener(
+  "DOMContentLoaded",
+  function () {
+    PrivateEye({
+      defaultMessage: "This link is private to TTS.",
+      ignoreUrls: [
+        "18f.slack.com",
+        "docs.google.com",
+        "ea.gsa.gov",
+        "github.com/18F/security-incidents",
+        "gsa-tts.slack.com",
+        "insite.gsa.gov",
+      ],
+    });
+  },
+  false
+);

--- a/assets/js/private-eye.js
+++ b/assets/js/private-eye.js
@@ -1,0 +1,105 @@
+// https://github.com/18F/private-eye
+(function() {
+  'use strict';
+
+  var STYLES = 'a.private-link::after { content: "\\1F512"; font-size: 0.75em; vertical-align: top; }';
+  var STYLES_ID = '_privateEye-styles';
+
+  var DEFAULT_OPTIONS = {
+    defaultMessage: 'This is a link to a private site, which may or may not be accessible to you.',
+    wrapper: ''
+  };
+
+  var isString = function(str) { return !!str && typeof str === 'string'; };
+  var isArray = function(arr) { return !!arr && arr.length; };
+
+  var optionValidators = {
+    defaultMessage: isString,
+    wrapper: isString,
+    ignoreUrls: isArray,
+  };
+
+  function setStyles() {
+    var styles = document.createElement('style');
+    styles.innerHTML = STYLES;
+    styles.id = STYLES_ID;
+    document.body.appendChild(styles);
+  }
+
+  function getOptions(opts) {
+    var newObj = {};
+
+    for (var prop in DEFAULT_OPTIONS) {
+      newObj[prop] = DEFAULT_OPTIONS[prop];
+    }
+
+    for (var prop in opts) {
+      var val = opts[prop];
+
+      if (optionValidators[prop](val)) {
+        newObj[prop] = val;
+      }
+    }
+
+    return newObj;
+  }
+
+  var PrivateEye = function(opts) {
+    // The old docs recommend calling this as a function. This is here to detect
+    // those cases and make sure backward compatibility stays intact now that the
+    // new syntax is preferred.
+    if (!(this instanceof PrivateEye)) {
+      return new PrivateEye(opts);
+    }
+
+    // Don't add the styles to the page more than once.
+    if (!document.getElementById(STYLES_ID)) {
+      setStyles();
+    }
+
+    this.opts = getOptions(opts);
+
+    this.checkLinks();
+  };
+
+  PrivateEye.prototype.checkLinks = function() {
+    var self = this;
+
+    this.opts.ignoreUrls.forEach(function(url) {
+      var hrefValue;
+      var titleValue;
+
+      // If the `url` is an Object, then parse the properties `message` & `url`
+      if (url === Object(url)) {
+        titleValue = url.message;
+        hrefValue = url.url;
+      } else {
+        hrefValue = url;
+        titleValue = self.opts.defaultMessage;
+      }
+
+      var wrapper = self.opts.wrapper.length ? self.opts.wrapper + ' ' : '';
+      var selector = wrapper + 'a';
+      var anchors = document.querySelectorAll(selector);
+
+      Array.prototype.forEach.call(anchors, function(anchor) {
+        var anchorHref = anchor.href.toLowerCase().trim();
+
+        if (anchorHref.indexOf(hrefValue.toLowerCase()) !== -1) {
+          anchor.className += ' private-link';
+
+          // Only replace the anchor's title if it is empty
+          if (!anchor.title) {
+            anchor.title = titleValue;
+          }
+        }
+      });
+    });
+  }
+
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = PrivateEye;
+  } else {
+    window.PrivateEye = PrivateEye;
+  }
+})();


### PR DESCRIPTION
Closes #150

This pull request integrates [PrivateEye](https://github.com/18F/private-eye) to mark internal URLs as private (with a 🔒  icon).

**Screenshot:**

![Integration lock](https://user-images.githubusercontent.com/1779930/86172574-97cc0580-baec-11ea-8e44-9b24b53527a5.png)

[👀  Live Preview](https://federalist-0fc100fe-c4d0-4b8f-bd4f-7392edd7c16d.app.cloud.gov/preview/18f/development-guide/add/private-eye/integrations/)

**Implementation Notes:**

The approach is largely inherited from [18F/handbook](https://github.com/18F/handbook), which it seeks to imitate:

- Adds the plugin script as a local asset file
- Initializes in a (new) `application.js` during `DOMContentLoaded`

There are a couple differences:

- Formatting is applied to `application.js` using Prettier (v2) with default settings
- It only includes the subset of [URLs from the handbook initialization](https://github.com/18F/handbook/blob/3875342830ee68edff17a97dc2c953999f4e7f64/javascripts/application.js#L120-L150) which exist in the engineering guide

**Open Questions:**

- Are there additional URL patterns which wouldn't have existed in the Handbook initialization?
- Should all of the same URL patterns from handbook be incorporated here, in anticipation that they could be referenced in future document updates?