### PR TITLE
Default branch changed from master to main

### DIFF
--- a/_guide/_config.yml
+++ b/_guide/_config.yml
@@ -16,7 +16,7 @@ url: "https://engineering.18f.gov"
 github_info:
   organization: 18F
   repository: development-guide
-  default_branch: master
+  default_branch: main
 
 # Unique identifier across GSA for this website; the repository name is
 # usually a good site handle.


### PR DESCRIPTION
For consistency with the TTS branch convention for (new) repos. Related changes already complete on GitHub and Federalist.