### PR TITLE
Add laptop setup suggestions

### DIFF
--- a/_guide/_data/navigation.yml
+++ b/_guide/_data/navigation.yml
@@ -35,6 +35,8 @@ approach:
 tools:
   - text: Tools
     href: /integrations/
+  - text: Laptop Setup 
+    href: /laptop-setup
   - text: Project Setup
     href: /project-setup/
   - text: Browser Testing

--- a/_guide/_pages/laptop-setup.md
+++ b/_guide/_pages/laptop-setup.md
@@ -1,0 +1,79 @@
+---
+title: Laptop Setup 
+sidenav: tools
+sticky_sidenav: true
+---
+
+While you are welcome to customize your laptop, here are some tools that have worked for others on the engineering team!
+
+* [ChromeDriver] for headless website testing
+* [chruby] for managing [Ruby] versions. 
+* [Cloud Foundry CLI] for command line access to 18F's Cloud Foundry-based application platform
+* [Docker] for all your containerization needs
+* [git-seekret] for preventing you from committing passwords and other sensitive information to a git repository
+* [GitHub Desktop] for setting up your SSH keys automatically
+* [Homebrew] for managing operating system libraries
+* [Homebrew Cask] for quickly installing Mac apps from the command line
+* [Homebrew Services] so you can easily stop, start, and restart services
+* [hub] for interacting with the GitHub API
+* [nvm] for managing Node.js versions if you do not have [Node.js] already installed (Includes latest [Node.js] and [NPM], for running apps and installing JavaScript packages)
+* [pyenv] for managing Python versions if you do not have [Python] already installed (includes the latest 3.x [Python])
+* [ruby-install] for installing different versions of Ruby
+* [Slack] for communicating with your team
+* [The Silver Searcher] for finding things in files
+* [Virtualenv] for creating isolated Python environments (via [pyenv] if it is installed)
+* [Virtualenvwrapper] for extending Virtualenv (via [pyenv] if it is installed)
+* [Zsh] as your shell
+
+[ChromeDriver]: http://chromedriver.chromium.org/
+[chruby]: https://github.com/postmodern/chruby
+[Cloud Foundry CLI]: https://github.com/cloudfoundry/cli
+[Docker]: https://www.docker.com/
+[git-seekret]: https://github.com/18F/git-seekret
+[Github Desktop]: https://desktop.github.com/
+[Homebrew]: http://brew.sh/
+[Homebrew Cask]: https://github.com/Homebrew/homebrew-cask
+[Homebrew Services]: https://github.com/Homebrew/homebrew-services
+[hub]: https://github.com/github/hub
+[Node.js]: http://nodejs.org/
+[NPM]: https://www.npmjs.org/
+[nvm]: https://github.com/nvm-sh/nvm
+[pyenv]: https://github.com/yyuu/pyenv/
+[Python]: https://www.python.org/
+[Ruby]: https://www.ruby-lang.org/en/
+[ruby-install]: https://github.com/postmodern/ruby-install
+[Slack]: https://slack.com/
+[The Silver Searcher]: https://github.com/ggreer/the_silver_searcher
+[Virtualenv]: https://virtualenv.pypa.io/en/latest/
+[Virtualenvwrapper]: http://virtualenvwrapper.readthedocs.org/en/latest/#
+[Zsh]: http://www.zsh.org/
+
+
+## Other customizations
+
+* [Atom] - GitHub's open source text editor
+* [Exuberant Ctags] for indexing files for vim tab completion
+* [Firefox] for testing your website on a browser other than Chrome
+* [iTerm2] - an awesome replacement for the OS X Terminal
+* [reattach-to-user-namespace] to allow copy and paste from Tmux
+* [Spectacle] - automatic window manipulation
+* [Sublime Text 3] for coding all the things
+* [Tmux] for saving project state and switching between projects
+* [Vim] for those who prefer the command line
+* [VSCode] - Microsoft's open source text editor
+
+[Atom]: https://atom.io/
+[Exuberant Ctags]: http://ctags.sourceforge.net/
+[Firefox]: https://www.mozilla.org/en-US/firefox/new/
+[iTerm2]: http://iterm2.com/
+[reattach-to-user-namespace]: https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard
+[Spectacle]: https://www.spectacleapp.com/
+[Sublime Text 3]: http://www.sublimetext.com/3
+[Tmux]: https://tmux.github.io/
+[Vim]: http://www.vim.org/
+[VSCode]: https://code.visualstudio.com/
+
+These suggestions were culled from the deprecated (as of October 2020) [laptop script]. 
+If you are looking for references on how to build personal dotfiles, that repo may be of use.
+
+[laptop script]: https://github.com/18F/laptop


### PR DESCRIPTION
The laptop script has been deprecated, but the list of what it installed seems useful to have a reference to for onboarding engineers. (As was suggested in the comments of [this PR](https://github.com/18F/handbook/pull/2186).

This PR just takes the list and drops it into the engineering guide as some software suggestions, with a link to the archived laptop script for reference or in case anyone is interested in a way to setup personak dotfiles.