### PR TITLE
Clarify classification tags

### DIFF
--- a/_guide/_pages/index.md
+++ b/_guide/_pages/index.md
@@ -15,8 +15,11 @@ This guide is where the TTS Engineering Practices Guild collects its best practi
 
 ## How we classify best practices
 
-These documents are structured by topic; under several topics we indicate "Requirement",
+These documents are structured by topic; under topics we have classified we indicate "Requirement",
 "Standard", "Default", "Suggestion", and "Caution".
+
+If a classification is not present on a topic or a reference to a tool or practice, it should be presumed
+to be a {%include components/tag-suggestion.html %} and the decision is left at your discretion. If you are unsure, ask in #dev, as the topic or tool may be a good candidate for classification.
 
 {%include components/tag-requirement.html %} indicates practices that *must* be done for
 regulatory, legal, compliance, or other reasons.

--- a/_guide/_pages/index.md
+++ b/_guide/_pages/index.md
@@ -15,7 +15,7 @@ This guide is where the TTS Engineering Practices Guild collects its best practi
 
 ## How we classify best practices
 
-These documents are structured by topic; under each, we include "Requirement",
+These documents are structured by topic; under several topics we indicate "Requirement",
 "Standard", "Default", "Suggestion", and "Caution".
 
 {%include components/tag-requirement.html %} indicates practices that *must* be done for
@@ -34,3 +34,6 @@ they're not widely used enough to be defaults, but are worth considering.
 
 {%include components/tag-caution.html %} marks approaches that have significant pitfalls or should not be used for
 security/compliance reasons.
+
+If a specific classification is not present on a topic or reference to a tool or practice, it should be presumed
+to be a {%include components/tag-suggestion.html %}.


### PR DESCRIPTION
Based on feedback, clarify our classification tags as we've only applied them to portions of the guide and likely will never explicitly tag every topic, sub-section, etc.