### PR TITLE
Add the new GH officially maintained CLI tool to the list of laptop tools

### DIFF
--- a/_pages/laptop-setup.md
+++ b/_pages/laptop-setup.md
@@ -15,7 +15,7 @@ While you are welcome to customize your laptop, here are some tools that have wo
 * [Homebrew] for managing operating system libraries
 * [Homebrew Cask] for quickly installing Mac apps from the command line
 * [Homebrew Services] so you can easily stop, start, and restart services
-* [hub] for interacting with the GitHub API
+* [gh] (official) or [hub] (unofficial) GitHub-maintained CLI tools for interacting with the GitHub API
 * [nvm] for managing Node.js versions if you do not have [Node.js] already installed (Includes latest [Node.js] and [NPM], for running apps and installing JavaScript packages)
 * [pyenv] for managing Python versions if you do not have [Python] already installed (includes the latest 3.x [Python])
 * [ruby-install] for installing different versions of Ruby
@@ -34,6 +34,7 @@ While you are welcome to customize your laptop, here are some tools that have wo
 [Homebrew]: http://brew.sh/
 [Homebrew Cask]: https://github.com/Homebrew/homebrew-cask
 [Homebrew Services]: https://github.com/Homebrew/homebrew-services
+[gh]: https://cli.github.com/
 [hub]: https://github.com/github/hub
 [Node.js]: http://nodejs.org/
 [NPM]: https://www.npmjs.org/


### PR DESCRIPTION
In 2020 GitHub launched [`gh`](https://cli.github.com/), an officially maintained easy-to-use CLI tool. The previous tool, `hub`, is now listed as "unofficial" on their repo. It is still maintained, but Github recommends using `gh` so I thought I'd add it here while still keeping `hub`. Personally, I have had a great experience with `gh`.

More information about the difference here: https://github.com/cli/cli/blob/trunk/docs/gh-vs-hub.md