### PR TITLE
Remove CodeCov, add CodeQL on GitHub

### DIFF
--- a/_pages/project-setup.md
+++ b/_pages/project-setup.md
@@ -119,7 +119,7 @@ project, that might not be caught in a code review. Static analysis tools catch
 duplication, security concerns, and more. Also see [Static Security
 Analysis](https://before-you-ship.18f.gov/security/static-analysis/).
 
-- [CodeQL on GitHub](https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/setting-up-code-scanning-for-a-repository) (for security analysis) {%include components/tag-standard.html %}
+- [CodeQL on GitHub](https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/setting-up-code-scanning-for-a-repository) (for security analysis) {%include components/tag-default.html %}
 - [Code Climate Quality](https://codeclimate.com/quality/) (for maintainability metrics) {%include components/tag-suggestion.html %}
 
 ## Dependency management

--- a/_pages/project-setup.md
+++ b/_pages/project-setup.md
@@ -109,7 +109,6 @@ are aggregated and reported on the entire project, in addition to reports on
 individual components.
 
 - [Code Climate Quality](https://codeclimate.com/quality/) {%include components/tag-suggestion.html %}
-- [CodeCov](https://codecov.io/) {%include components/tag-suggestion.html %}
 
 ## Static analysis for code quality
 
@@ -120,7 +119,8 @@ project, that might not be caught in a code review. Static analysis tools catch
 duplication, security concerns, and more. Also see [Static Security
 Analysis](https://before-you-ship.18f.gov/security/static-analysis/).
 
-- [Code Climate Quality](https://codeclimate.com/quality/) {%include components/tag-suggestion.html %}
+- [CodeQL on GitHub](https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/setting-up-code-scanning-for-a-repository) (for security analysis) {%include components/tag-standard.html %}
+- [Code Climate Quality](https://codeclimate.com/quality/) (for maintainability metrics) {%include components/tag-suggestion.html %}
 
 ## Dependency management
 


### PR DESCRIPTION
CodeCov is not approved for use (no GSA ATO, not in GEAR). CodeQL is approved by virtue of it being part of GitHub.