### PR TITLE
Mention Conventional Comments syntax as a code review strategy

### DIFF
--- a/_pages/code-review.md
+++ b/_pages/code-review.md
@@ -50,7 +50,7 @@ Some guiding questions for your team's code review discussion:
 - How many people are expected to review each pull request?
 - If a patch is worked on in a pairing session, how does it get merged?
 - Does your team make use of any tools to aid in code reviews? (eg: CI, Static
-  Analysis, linters)
+  Analysis, linters, [Conventional Comments syntax](https://conventionalcomments.org/))
 - Are there any automated tools that you are not using that you would like to try?
 - If commit messages aren't up to par, should they be modified before the PR is?
 - What do you look for when conducting a code review?
@@ -119,6 +119,7 @@ accomplish this, everyone should consider these tips.
   them. ("What do you think about such-and-such here?")
 - Sign off on the pull request with a :thumbsup: or "Ready to merge" comment.
 - Wait to merge the branch until it has passed Continuous Integration testing.
+- Consider using a syntax like [Conventional Comments](https://conventionalcomments.org/) in order to clarify whether a comment is blocking or non-blocking for merging the PR.
 
 ### Who merges
 


### PR DESCRIPTION
Thought it'd be a good idea to add this resource for code reviews, since a few engineers have asked about it. 

Pa11y failures addressed in [this PR](https://github.com/18F/development-guide/pull/277)