### PR TITLE
Fix left-side nav current page highlight for certain pages

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -41,13 +41,13 @@ approach:
   - text: Release Strategies
     href: /release-strategies/
   - text: Example Workflows
-    href: /example-workflows
+    href: /example-workflows/
 
 tools:
   - text: Tools
     href: /integrations/
   - text: Laptop Setup
-    href: /laptop-setup
+    href: /laptop-setup/
   - text: Project Setup
     href: /project-setup/
   - text: Docker for Development
@@ -61,7 +61,7 @@ tools:
   - text: Datastore Selection
     href: /datastore-selection/
   - text: Choosing a Web App Architecture
-    href: /web-architecture
+    href: /web-architecture/
   - text: SharePoint Primer
     href: /sharepoint/
 


### PR DESCRIPTION
**Description:**

Certain pages (like Tools -> Laptop Setup) don't show up in the left navigation bar highlighted as the current page being viewed. This could lead to possible confusion on where the page is actually located, but also it breaks the convention of how the other pages work within the guide.

This PR fixes it by adds in missing `/` on all the URLs in [_data/navigation.yml](_data/navigation.yml) so that the site knows where the page is in the navigation hierarchy.


**Before and After Screenshots:**

![image](https://user-images.githubusercontent.com/2601974/134749829-a0af782e-aef0-4d58-9aff-745418e55851.png)

![image](https://user-images.githubusercontent.com/2601974/134749871-4cd29d95-6607-439c-bf6f-98ebc50dbfd9.png)
