### PR TITLE
Replace homepage with set of categorized links

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,4 @@
 primary:
-  - text: Sitemap
-    href: /
-    name: sitemap
   - text: About this guide
     href: /about
     name: about
@@ -17,10 +14,6 @@ primary:
   - text: Security
     href: /security/
     name: security
-
-sitemap:
-  - text: Sitemap
-    href: /
 
 about:
   - text: About this guide

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,6 +1,6 @@
 primary:
   - text: About this guide
-    href: /
+    href: /about
     name: about
   - text: Our approach
     href: /workflow/
@@ -17,7 +17,7 @@ primary:
 
 about:
   - text: About this guide
-    href: /
+    href: /about
   - text: License
     href: /license/
   - text: Resources

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,4 +1,7 @@
 primary:
+  - text: Sitemap
+    href: /
+    name: sitemap
   - text: About this guide
     href: /about
     name: about
@@ -14,6 +17,10 @@ primary:
   - text: Security
     href: /security/
     name: security
+
+sitemap:
+  - text: Sitemap
+    href: /
 
 about:
   - text: About this guide

--- a/_includes/categorylinks.html
+++ b/_includes/categorylinks.html
@@ -1,0 +1,9 @@
+    <div class="tablet:grid-col">
+      {% for link in include.links %}
+        {% if forloop.first == true %}
+          <h3><a href = "{{ link.href }}">{{ link.text }}</a></h3>
+        {% else %}
+          <a href = "{{ link.href }}">{{ link.text }}</a><br />
+        {% endif %}
+      {% endfor %}
+    </div>

--- a/_includes/categorylinks.html
+++ b/_includes/categorylinks.html
@@ -1,7 +1,8 @@
     <div class="tablet:grid-col">
       {% for link in include.links %}
         {% if forloop.first == true %}
-          <h3><a href = "{{ link.href }}">{{ link.text }}</a></h3>
+          <h3>{{ link.text }}</h3>
+          <a href = "{{ link.href }}">Overview</a><br />
         {% else %}
           <a href = "{{ link.href }}">{{ link.text }}</a><br />
         {% endif %}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -6,10 +6,7 @@ sticky_sidenav: true
 subnav:
   - text: How we classify best practices
     href: "#how-we-classify-best-practices"
-categories: about
 ---
-
-_A set of guidelines and best practices for an awesome software engineering team._
 
 [Technology Transformation Services (TTS)](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services) — which includes [18F](https://18f.gsa.gov/), [Centers of Excellence (CoE)](https://coe.gsa.gov/), [Presidential Innovation Fellows (PIF)](https://presidentialinnovationfellows.gov/), and [TTS Solutions](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/tts-solutions) — promote best practices across specialty areas through guilds.
 

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -10,8 +10,6 @@ subnav:
 
 [Technology Transformation Services (TTS)](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services) — which includes [18F](https://18f.gsa.gov/), [Centers of Excellence (CoE)](https://coe.gsa.gov/), [Presidential Innovation Fellows (PIF)](https://presidentialinnovationfellows.gov/), and [TTS Solutions](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/tts-solutions) — promote best practices across specialty areas through guilds.
 
-This guide is where the TTS Engineering Practices Guild collects its best practices and resources for software development at TTS, as well as on our partner engagements. Our focus is cloud-native digital services and our recommendations in this guide reflect the needs of that domain.
-
 Getting new practices into the guide is pretty light on process. Feel free to raise a topic in Slack or at a guild meeting and drive to some consensus. Once you've done that, document your findings, submit a PR, and ask in #dev for a quick review. If you think a proposal might be controversial after getting some consensus prior, please post the draft PR to #dev (and elsewhere if you don’t think target audience is in that channel) and solicit feedback.
 
 ## How we classify best practices

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,0 +1,46 @@
+---
+title: About this guide
+permalink: /about
+sidenav: about
+sticky_sidenav: true
+subnav:
+  - text: How we classify best practices
+    href: "#how-we-classify-best-practices"
+categories: about
+---
+
+_A set of guidelines and best practices for an awesome software engineering team._
+
+[Technology Transformation Services (TTS)](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services) — which includes [18F](https://18f.gsa.gov/), [Centers of Excellence (CoE)](https://coe.gsa.gov/), [Presidential Innovation Fellows (PIF)](https://presidentialinnovationfellows.gov/), and [TTS Solutions](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/tts-solutions) — promote best practices across specialty areas through guilds.
+
+This guide is where the TTS Engineering Practices Guild collects its best practices and resources for software development at TTS, as well as on our partner engagements. Our focus is cloud-native digital services and our recommendations in this guide reflect the needs of that domain.
+
+Getting new practices into the guide is pretty light on process. Feel free to raise a topic in Slack or at a guild meeting and drive to some consensus. Once you've done that, document your findings, submit a PR, and ask in #dev for a quick review. If you think a proposal might be controversial after getting some consensus prior, please post the draft PR to #dev (and elsewhere if you don’t think target audience is in that channel) and solicit feedback.
+
+## How we classify best practices
+
+These documents are structured by topic; under topics we have classified we indicate "Requirement",
+"Standard", "Default", "Suggestion", and "Caution".
+
+If a classification is not present on a topic or a reference to a tool or practice, it should be presumed
+to be a {%include components/tag-suggestion.html %} and the decision is left at your discretion. If you are unsure, ask in #dev, as the topic or tool may be a good candidate for classification.
+
+{%include components/tag-requirement.html %} indicates practices that _must_ be done for
+regulatory, legal, compliance, or other reasons.
+
+{%include components/tag-standard.html %} signifies practices that have a strong consensus across TTS; they
+should generally be followed to ease the ATO process and make on-boarding
+simpler.
+
+{%include components/tag-default.html %} practices are safe selections that tend to be used by a large number of our
+projects; you may find yourself with a better or more tailored solution,
+however.
+
+{%include components/tag-suggestion.html %} indicates examples that have worked well on a project or two;
+they're not widely used enough to be defaults, but are worth considering.
+
+{%include components/tag-caution.html %} marks approaches that have significant pitfalls or should not be used for
+security/compliance reasons.
+
+If a specific classification is not present on a topic or reference to a tool or practice, it should be presumed
+to be a {%include components/tag-suggestion.html %}.

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -8,23 +8,37 @@ _A set of guidelines and best practices for an awesome software engineering team
 
 This guide is where the TTS Engineering Practices Guild collects its best practices and resources for software development at TTS, as well as on our partner engagements. Our focus is cloud-native digital services and our recommendations in this guide reflect the needs of that domain.
 
-{% for cat in site.data.navigation %}
+<div class="grid-container">
+  <div class="grid-row">
+    {% include categorylinks.html links=site.data.navigation.about %}
+    {% include categorylinks.html links=site.data.navigation.approach %}
+  </div>
+  <div class="grid-row">
+    {% include categorylinks.html links=site.data.navigation.tools %}
+    {% include categorylinks.html links=site.data.navigation.languages %}
+  </div>
+  <div class="grid-row">
+    {% include categorylinks.html links=site.data.navigation.security %}
+  </div>
+</div>
 
-{% if cat[0] != "primary" and cat[0] != "sitemap" %}
+<hr />
 
-{% for link in cat[1] %}
+<div class="layout-table-of-contents">
+  <div class="wrapper usa-prose">
+      {% for cat in site.data.navigation %}
+      {% if cat[0] != "primary" %}
+        {% for link in cat[1] %}
+          {% if forloop.first == true %}
+            <h3><a href = "{{ link.href }}">{{ link.text }}</a></h3>
+          {% else %}
+            <a href = "{{ link.href }}">{{ link.text }}</a><br />
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+      {% endfor %}
+      <hr />
+  </div>
+</div>
 
-{% if forloop.first == true %}
-
-### [{{ link.text }}]({{ link.href }})
-
-{% else %}
-
-- [{{ link.text }}]({{ link.href }})
-  {% endif %}
-  {% endfor %}
-
----
-
-{% endif %}
-{% endfor %}
+<hr />

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -1,7 +1,6 @@
 ---
 title: TTS Engineering Guide
 permalink: /
-sidenav: sitemap
 sticky_sidenav: true
 ---
 

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -21,24 +21,3 @@ This guide is where the TTS Engineering Practices Guild collects its best practi
     {% include categorylinks.html links=site.data.navigation.security %}
   </div>
 </div>
-
-<hr />
-
-<div class="layout-table-of-contents">
-  <div class="wrapper usa-prose">
-      {% for cat in site.data.navigation %}
-      {% if cat[0] != "primary" %}
-        {% for link in cat[1] %}
-          {% if forloop.first == true %}
-            <h3><a href = "{{ link.href }}">{{ link.text }}</a></h3>
-          {% else %}
-            <a href = "{{ link.href }}">{{ link.text }}</a><br />
-          {% endif %}
-        {% endfor %}
-      {% endif %}
-      {% endfor %}
-      <hr />
-  </div>
-</div>
-
-<hr />

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -1,6 +1,7 @@
 ---
 title: TTS Engineering Guide
 permalink: /
+sidenav: sitemap
 sticky_sidenav: true
 ---
 
@@ -8,14 +9,21 @@ _A set of guidelines and best practices for an awesome software engineering team
 
 {% for cat in site.data.navigation %}
 
-{% if cat[0] != "primary" %}
-
-## {{ cat[0] | capitalize }}
+{% if cat[0] != "primary" and cat[0] != "sitemap" %}
 
 {% for link in cat[1] %}
 
-- [{{ link.text }}]({{ link.href }})
+{% if forloop.first == true %}
 
-{% endfor %}
+### [{{ link.text }}]({{ link.href }})
+
+{% else %}
+
+- [{{ link.text }}]({{ link.href }})
+  {% endif %}
+  {% endfor %}
+
+---
+
 {% endif %}
 {% endfor %}

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -1,44 +1,21 @@
 ---
-title: About this guide
+title: TTS Engineering Guide
 permalink: /
-sidenav: about
 sticky_sidenav: true
-subnav:
-  - text: How we classify best practices
-    href: '#how-we-classify-best-practices'
 ---
-*A set of guidelines and best practices for an awesome software engineering team.*
 
-[Technology Transformation Services (TTS)](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services) — which includes [18F](https://18f.gsa.gov/), [Centers of Excellence (CoE)](https://coe.gsa.gov/), [Presidential Innovation Fellows (PIF)](https://presidentialinnovationfellows.gov/), and [TTS Solutions](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/tts-solutions) — promote best practices across specialty areas through guilds.
+_A set of guidelines and best practices for an awesome software engineering team._
 
-This guide is where the TTS Engineering Practices Guild collects its best practices and resources for software development at TTS, as well as on our partner engagements. Our focus is cloud-native digital services and our recommendations in this guide reflect the needs of that domain.
+{% for cat in site.data.navigation %}
 
-Getting new practices into the guide is pretty light on process. Feel free to raise a topic in Slack or at a guild meeting and drive to some consensus. Once you've done that, document your findings, submit a PR, and ask in #dev for a quick review. If you think a proposal might be controversial after getting some consensus prior, please post the draft PR to #dev (and elsewhere if you don’t think target audience is in that channel) and solicit feedback.
+{% if cat[0] != "primary" %}
 
-## How we classify best practices
+## {{ cat[0] | capitalize }}
 
-These documents are structured by topic; under topics we have classified we indicate "Requirement",
-"Standard", "Default", "Suggestion", and "Caution".
+{% for link in cat[1] %}
 
-If a classification is not present on a topic or a reference to a tool or practice, it should be presumed
-to be a {%include components/tag-suggestion.html %} and the decision is left at your discretion. If you are unsure, ask in #dev, as the topic or tool may be a good candidate for classification.
+- [{{ link.text }}]({{ link.href }})
 
-{%include components/tag-requirement.html %} indicates practices that *must* be done for
-regulatory, legal, compliance, or other reasons.
-
-{%include components/tag-standard.html %} signifies practices that have a strong consensus across TTS; they
-should generally be followed to ease the ATO process and make on-boarding
-simpler.
-
-{%include components/tag-default.html %} practices are safe selections that tend to be used by a large number of our
-projects; you may find yourself with a better or more tailored solution,
-however.
-
-{%include components/tag-suggestion.html %} indicates examples that have worked well on a project or two;
-they're not widely used enough to be defaults, but are worth considering.
-
-{%include components/tag-caution.html %} marks approaches that have significant pitfalls or should not be used for
-security/compliance reasons.
-
-If a specific classification is not present on a topic or reference to a tool or practice, it should be presumed
-to be a {%include components/tag-suggestion.html %}.
+{% endfor %}
+{% endif %}
+{% endfor %}

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -6,6 +6,8 @@ sticky_sidenav: true
 
 _A set of guidelines and best practices for an awesome software engineering team._
 
+This guide is where the TTS Engineering Practices Guild collects its best practices and resources for software development at TTS, as well as on our partner engagements. Our focus is cloud-native digital services and our recommendations in this guide reflect the needs of that domain.
+
 {% for cat in site.data.navigation %}
 
 {% if cat[0] != "primary" and cat[0] != "sitemap" %}


### PR DESCRIPTION
* Current homepage has been moved to an "About" page and is the link for "About this Guide" in the top nav.
* Content is delivered using the already existing `_data/navigation.yml` file for link metadata
* An `_includes/categorylinks.html` defines each box of links in the homepage grid
* index.md now has a simple block of `<div>`s with calls to the categorylinks.html include