### PR TITLE
Publications TTS folks have said they have read

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -64,8 +64,8 @@ tools:
     href: /web-architecture/
   - text: SharePoint Primer
     href: /sharepoint/
-  - text: Reading List
-    href: /reading-list/
+  - text: Books we've read
+    href: /books-we-have-read/
 
 languages:
   - text: Languages & Runtimes

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -64,6 +64,8 @@ tools:
     href: /web-architecture/
   - text: SharePoint Primer
     href: /sharepoint/
+  - text: Reading List
+    href: /reading-list/
 
 languages:
   - text: Languages & Runtimes

--- a/_pages/books-we-have-read.md
+++ b/_pages/books-we-have-read.md
@@ -1,10 +1,10 @@
 ---
-title: Reading List
+title: Books we've read
 sidenav: tools
 sticky_sidenav: true
 ---
 
-Engineers at TTS like to read! Here are a few publications that folks have mentioned that they have read in #dev and elsewhere.
+Engineers at TTS like to read! Here are a few books and other publications that folks have mentioned that they have read in #dev and elsewhere.
 
 - *Accelerate: The Science of Lean Software and DevOps: Building and Scaling High Performing Technology Organizations* by Nicole Forsgren, Jez Humble, and Gene Kim
 - *Being Wrong: Adventures in the Margin of Error* by Kathryn Schulz

--- a/_pages/reading-list.md
+++ b/_pages/reading-list.md
@@ -1,0 +1,52 @@
+---
+title: Reading List
+sidenav: tools
+sticky_sidenav: true
+---
+
+Engineers at TTS like to read! Here are a few publications that folks have mentioned that they have read in #dev and elsewhere.
+
+- *Accelerate: The Science of Lean Software and DevOps: Building and Scaling High Performing Technology Organizations* by Nicole Forsgren, Jez Humble, and Gene Kim
+- *Being Wrong: Adventures in the Margin of Error* by Kathryn Schulz
+- *Debugging Teams: Better Productivity through Collaboration* by Brian W. Fitzpatrick
+- *The Design of Everyday Things* by Don Norman
+- *Domain-Driven Design Distilled* by Vaughn Vernon
+- *Domain-Driven Design: Tackling Complexity in the Heart of Software* by Eric Evans
+- *The Effective Engineer* by Edmond Lau and Bret Taylor
+- *Fifty Quick Ideas to Improve Your User Stories* by Gojko Adzic and David Evans
+- *The Field Guide to Understanding 'Human Error'* by Sidney Dekker
+- *Inviting Disaster: Lessons From the Edge of Technology* by James R. Chiles
+- *It Doesn't Have to Be Crazy at Work* by Jason Fried and David Heinemeier Hansson
+- *Kill It with Fire: Manage Aging Computer Systems (and Future Proof Modern Ones)* by Marianne Bellotti
+- *The Manager's Path: A Guide for Tech Leaders Navigating Growth and Change* by Camille Fournier
+- *Monolith to Microservices: Evolutionary Patterns to Transform Your Monolith* by Sam Newman
+- *The Mythical Man-Month: Essays on Software Engineering* by  Frederick Brooks Jr.
+- *[Prototyping for tiny fingers](http://fpl.cs.depaul.edu/jriely/360/extras/prototyping-for-tiny-fingers.pdf)* by Marc Rettig
+- *[Reflections on Trusting Trust ](https://www.cs.cmu.edu/~rdriley/487/papers/Thompson_1984_ReflectionsonTrustingTrust.pdf)* by Ken Thompson
+- *[Shape Up: Stop Running in Circles
+and Ship Work that Matters](https://basecamp.com/shapeup/webbook)* by Ryan Singer
+- *[Site Reliability Engineering: How Google Runs Production Systems](https://sre.google/sre-book/table-of-contents/)* by Betsy Beyer, Chris Jones, Jennifer Petoff, and Niall Richard Murphy
+- *Systems Performance: Enterprise and the Cloud* by Brendan Gregg
+- *Threat Modeling: Designing for Security* by Adam Shostack
+- *[Twenty Ways to Split Stories](https://xp123.com/articles/twenty-ways-to-split-stories/)* by Bill Wake
+- *A Whack on the Side of the Head: How You Can Be More Creative* by Roger von Oech
+- *[You Reap What You Code](https://ferd.ca/you-reap-what-you-code.html)* by Fred Hebert
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Original Slack thread is at https://gsa-tts.slack.com/archives/C02CD5VUQ/p1603474669167500

To be clear, this is not an endorsement, just a list of books that TTS folks have claimed to have read related to software development, building and engineering products. 

I decided against linking to any particular book reseller. Tracking down a good direct link each book's publisher was also a bit tricky. So in the end I only provided direct links to content that is freely available online.

`Tools` seemed to be the most appropriate, existing heading to put this list under.