### PR TITLE
Add API standards

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -38,6 +38,8 @@ approach:
     href: /architecture-reviews/
   - text: Front-End Disciplines
     href: /frontend/
+  - text: APIs
+    href: /apis/
   - text: Release Strategies
     href: /release-strategies/
   - text: Example Workflows

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -107,7 +107,8 @@ General JSON guidelines:
 
 {% include components/tag-standard.html %} And specifically, [use ISO 8601](https://xkcd.com/1179/), in UTC.
 
-For just dates, that looks like `2013-02-27`. For full times, that's of the form `2013-02-27T10:00:00Z`.
+For just dates, that looks like `{{ site.time | date: '%Y-%m-%d' }}`. For full times, that's of the form 
+`{{ site.time | date: '%Y-%m-%dT%TZ' }}`.
 
 This date format is used all over the web, and puts each field in consistent order -- from least granular to most granular.
 

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -1,0 +1,223 @@
+---
+title: APIs
+sidenav: approach
+sticky_sidenav: true
+---
+
+# 18F API Standards
+
+**[18F](https://18f.gsa.gov/)** is a technology team inside the US federal government. 18F is very API-focused: our first project was an [API for business opportunities](https://fbopen.gsa.gov/).
+
+This document captures **18F's view of API best practices and standards**. We aim to incorporate as many of them as possible into our work.
+
+APIs, like other web applications, vary greatly in implementation and design, depending on the situation and the problem the application is solving.
+
+This document provides a mix of:
+
+* **High level design guidance** that individual APIs interpret to meet their needs.
+* **Low level web practices** that most modern HTTP APIs use.
+
+### Design for common use cases
+
+For APIs that syndicate data, consider several common client use cases:
+
+* **Bulk data.** Clients often wish to establish their own copy of the API's dataset in its entirety. For example, someone might like to build their own search engine on top of the dataset, using different parameters and technology than the "official" API allows. If the API can't easily act as a bulk data provider, provide a separate mechanism for acquiring the backing dataset in bulk.
+* **Staying up to date.** Especially for large datasets, clients may want to keep their dataset up to date without downloading the data set after every change. If this is a use case for the API, prioritize it in the design.
+* **Driving expensive actions.** What would happen if a client wanted to automatically send text messages to thousands of people or light up the side of a skyscraper every time a new record appears? Consider whether the API's records will always be in a reliable unchanging order, and whether they tend to appear in clumps or in a steady stream. Generally speaking, consider the "entropy" an API client would experience.
+
+### Using one's own API
+
+The #1 best way to understand and address the weaknesses in an API's design and implementation is to use it in a production system.
+
+Whenever feasible, design an API in parallel with an accompanying integration of that API.
+
+### Point of contact
+
+Have an obvious mechanism for clients to report issues and ask questions about the API.
+
+When using GitHub for an API's code, use the associated issue tracker. In addition, publish an email address for direct, non-public inquiries.
+
+### Notifications of updates
+
+Have a simple mechanism for clients to follow changes to the API.
+
+Common ways to do this include a mailing list, or a [dedicated developer blog](https://developer.github.com/changes/) with an RSS feed.
+
+### API Endpoints
+
+An "endpoint" is a combination of two things:
+
+* The verb (e.g. `GET` or `POST`)
+* The URL path (e.g. `/articles`)
+
+Information can be passed to an endpoint in either of two ways:
+
+* The URL query string (e.g. `?year=2014`)
+* HTTP headers (e.g. `X-Api-Key: my-key`)
+
+When people say "RESTful" nowadays, they really mean designing simple, intuitive endpoints that represent unique functions in the API.
+
+Generally speaking:
+
+* **Avoid single-endpoint APIs.** Don't jam multiple operations into the same endpoint with the same HTTP verb.
+* **Prioritize simplicity.** It should be easy to guess what an endpoint does by looking at the URL and HTTP verb, without needing to see a query string.
+* Endpoint URLs should advertise resources, and **avoid verbs**.
+
+Some examples of these principles in action:
+
+* [FBOpen API documentation](https://18f.github.io/fbopen/)
+* [OpenFDA example query](https://open.fda.gov/api/reference/#example-query)
+* [Sunlight Congress API methods](https://sunlightlabs.github.io/congress/#using-the-api)
+
+### Just use JSON
+
+[JSON](https://en.wikipedia.org/wiki/JSON) is an excellent, widely supported transport format, suitable for many web APIs.
+
+Supporting JSON and only JSON is a practical default for APIs, and generally reduces complexity for both the API provider and consumer.
+
+General JSON guidelines:
+
+* Responses should be **a JSON object** (not an array). Using an array to return results limits the ability to include metadata about results, and limits the API's ability to add additional top-level keys in the future.
+* **Don't use unpredictable keys**. Parsing a JSON response where keys are unpredictable (e.g. derived from data) is difficult, and adds friction for clients.
+* **Use consistent case for keys**. Whether you use `under_score` or `CamelCase` for your API keys, make sure you are consistent.
+
+### Use a consistent date format
+
+And specifically, [use ISO 8601](https://xkcd.com/1179/), in UTC.
+
+For just dates, that looks like `2013-02-27`. For full times, that's of the form `2013-02-27T10:00:00Z`.
+
+This date format is used all over the web, and puts each field in consistent order -- from least granular to most granular.
+
+
+### API Keys
+
+These standards do not take a position on whether or not to use API keys.
+
+But _if_ keys are used to manage and authenticate API access, the API should allow some sort of unauthenticated access, without keys.
+
+This allows newcomers to use and experiment with the API in demo environments and with simple `curl`/`wget`/etc. requests.
+
+Consider whether one of your product goals is to allow a certain level of normal production use of the API without enforcing advanced registration by clients.
+
+
+### Error handling
+
+Handle all errors (including otherwise uncaught exceptions) and return a data structure in the same format as the rest of the API.
+
+For example, a JSON API might provide the following when an uncaught exception occurs:
+
+```json
+{
+  "message": "Description of the error.",
+  "exception": "[detailed stacktrace]"
+}
+```
+
+HTTP responses with error details should use a `4XX` status code to indicate a client-side failure (such as invalid authorization, or an invalid parameter), and a `5XX` status code to indicate server-side failure (such as an uncaught exception).
+
+
+### Pagination
+
+If pagination is required to navigate datasets, use the method that makes the most sense for the API's data.
+
+#### Parameters
+
+Common patterns:
+
+* `page` and `per_page`. Intuitive for many use cases. Links to "page 2" may not always contain the same data.
+* `offset` and `limit`. This standard comes from the SQL database world, and is a good option when you need stable permalinks to result sets.
+* `since` and `limit`. Get everything "since" some ID or timestamp. Useful when it's a priority to let clients efficiently stay "in sync" with data. Generally requires result set order to be very stable.
+
+#### Metadata
+
+Include enough metadata so that clients can calculate how much data there is, and how and whether to fetch the next set of results.
+
+Example of how that might be implemented:
+
+```json
+{
+  "results": [ ... actual results ... ],
+  "pagination": {
+    "count": 2340,
+    "page": 4,
+    "per_page": 20
+  }
+}
+```
+
+### Always use HTTPS
+
+Any new API should use and require [HTTPS encryption](https://en.wikipedia.org/wiki/HTTP_Secure) (using TLS/SSL). HTTPS provides:
+
+* **Security**. The contents of the request are encrypted across the Internet.
+* **Authenticity**. A stronger guarantee that a client is communicating with the real API.
+* **Privacy**. Enhanced privacy for apps and users using the API. HTTP headers and query string parameters (among other things) will be encrypted.
+* **Compatibility**. Broader client-side compatibility. For CORS requests to the API to work on HTTPS websites -- to not be blocked as mixed content -- those requests must be over HTTPS.
+
+HTTPS should be configured using modern best practices, including ciphers that support [forward secrecy](https://en.wikipedia.org/wiki/Forward_secrecy), and [HTTP Strict Transport Security](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security). **This is not exhaustive**: use tools like [SSL Labs](https://www.ssllabs.com/ssltest/analyze.html) to evaluate an API's HTTPS configuration.
+
+For an existing API that runs over plain HTTP, the first step is to add HTTPS support, and update the documentation to declare it the default, use it in examples, etc.
+
+Then, evaluate the viability of disabling or redirecting plain HTTP requests. See [GSA/api.data.gov#34](https://github.com/18F/api.data.gov/issues/34) for a discussion of some of the issues involved with transitioning from HTTP->HTTPS.
+
+#### Server Name Indication
+
+If you can, use [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication) (SNI) to serve HTTPS requests.
+
+SNI is an extension to TLS, [first proposed in 2003](http://tools.ietf.org/html/rfc3546), that allows SSL certificates for multiple domains to be served from a single IP address.
+
+Using one IP address to host multiple HTTPS-enabled domains can significantly lower costs and complexity in server hosting and administration. This is especially true as IPv4 addresses become more rare and costly. SNI is a Good Idea, and it is widely supported.
+
+However, some clients and networks still do not properly support SNI. As of this writing, that includes:
+
+* Internet Explorer 8 and below on Windows XP
+* Android 2.3 (Gingerbread) and below.
+* All versions of Python 2.x (a version of Python 2.x with SNI [is planned](http://legacy.python.org/dev/peps/pep-0466/)).
+* Some enterprise network environments have been configured in some custom way that disables or interferes with SNI support. One identified network where this is the case: the White House.
+
+When implementing SSL support for an API, evaluate whether SNI support makes sense for the audience it serves.
+
+### Use UTF-8
+
+Just [use UTF-8](http://utf8everywhere.org).
+
+Expect accented characters or "smart quotes" in API output, even if they're not expected.
+
+An API should tell clients to expect UTF-8 by including a charset notation in the `Content-Type` header for responses.
+
+An API that returns JSON should use:
+
+```
+Content-Type: application/json; charset=utf-8
+```
+
+### CORS
+
+For clients to be able to use an API from inside web browsers, the API must [enable CORS](http://enable-cors.org).
+
+For the simplest and most common use case, where the entire API should be accessible from inside the browser, enabling CORS is as simple as including this HTTP header in all responses:
+
+```
+Access-Control-Allow-Origin: *
+```
+
+It's supported by [every modern browser](http://enable-cors.org/client.html), and will Just Work in many JavaScript clients, like [jQuery](https://jquery.com).
+
+For more advanced configuration, see the [W3C spec](http://www.w3.org/TR/cors/) or [Mozilla's guide](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).
+
+**What about JSONP?**
+
+JSONP is [not secure or performant](https://gist.github.com/tmcw/6244497). If IE8 or IE9 must be supported, use Microsoft's [XDomainRequest](http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx?Redirected=true) object instead of JSONP. There are [libraries](https://github.com/mapbox/corslite) to help with this.
+
+
+## Public domain
+
+This project is in the public domain within the United States, and
+copyright and related rights in the work worldwide are waived through
+the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+All contributions to this project will be released under the CC0
+dedication. By submitting a pull request, you are agreeing to comply
+with this waiver of copyright interest.
+

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -65,7 +65,7 @@ Some examples of these principles in action:
 
 ## Always use HTTPS
 
-Any new API should use and require [HTTPS encryption](https://en.wikipedia.org/wiki/HTTP_Secure). HTTPS provides:
+{% include components/tag-requirement.html %} Any new API should use and require [HTTPS encryption](https://en.wikipedia.org/wiki/HTTP_Secure). HTTPS provides:
 
 * **Security**. The contents of the request are encrypted across the Internet.
 * **Authenticity**. A stronger guarantee that a client is communicating with the real API.
@@ -79,7 +79,7 @@ The CIO Council provides two relevant guides:
 
 ## Use UTF-8
 
-Just [use UTF-8](http://utf8everywhere.org).
+{% include components/tag-requirement.html %} Just [use UTF-8](http://utf8everywhere.org).
 
 Expect accented characters or "smart quotes" in API output, even if they're not expected.
 
@@ -93,7 +93,7 @@ Content-Type: application/json; charset=utf-8
 
 ## Just use JSON 
 
-[JSON](https://en.wikipedia.org/wiki/JSON) is an excellent, widely supported transport format, suitable for many web APIs.
+{% include components/tag-standard.html %} [JSON](https://en.wikipedia.org/wiki/JSON) is an excellent, widely supported transport format, suitable for many web APIs.
 
 Supporting JSON and only JSON is a practical default for APIs, and generally reduces complexity for both the API provider and consumer.
 
@@ -105,7 +105,7 @@ General JSON guidelines:
 
 ## Use a consistent date format
 
-And specifically, [use ISO 8601](https://xkcd.com/1179/), in UTC.
+{% include components/tag-standard.html %} And specifically, [use ISO 8601](https://xkcd.com/1179/), in UTC.
 
 For just dates, that looks like `2013-02-27`. For full times, that's of the form `2013-02-27T10:00:00Z`.
 

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -16,7 +16,7 @@ This document provides a mix of:
 For APIs that syndicate data, consider several common client use cases:
 
 * **Bulk data.** Clients often wish to establish their own copy of the API's dataset in its entirety. For example, someone might like to build their own search engine on top of the dataset, using different parameters and technology than the "official" API allows. If the API can't easily act as a bulk data provider, provide a separate mechanism for acquiring the backing dataset in bulk.
-* **Staying up to date.** Especially for large datasets, clients may want to keep their dataset up to date without downloading the data set after every change. If this is a use case for the API, prioritize it in the design.
+* **Staying up to date.** Especially for large datasets, clients may want to keep their copy of the dataset up to date without downloading the entire dataset after every change. If this is a use case for the API, prioritize it in the design.
 * **Driving expensive actions.** What would happen if a client wanted to automatically send text messages to thousands of people or light up the side of a skyscraper every time a new record appears? Consider whether the API's records will always be in a reliable unchanging order, and whether they tend to appear in clumps or in a steady stream. Generally speaking, consider the "entropy" an API client would experience.
 
 ### Using one's own API
@@ -37,7 +37,7 @@ Have a simple mechanism for clients to follow changes to the API.
 
 Common ways to do this include a mailing list, or a [dedicated developer blog](https://developer.github.com/changes/) with an RSS feed.
 
-### API Endpoints
+### API endpoints
 
 An "endpoint" is a combination of two things:
 
@@ -85,7 +85,7 @@ For just dates, that looks like `2013-02-27`. For full times, that's of the form
 This date format is used all over the web, and puts each field in consistent order -- from least granular to most granular.
 
 
-### API Keys
+### API keys
 
 These standards do not take a position on whether or not to use API keys.
 

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -11,7 +11,7 @@ This document provides a mix of:
 * **High level design guidance** that individual APIs interpret to meet their needs.
 * **Low level web practices** that most modern HTTP APIs use.
 
-### Design for common use cases
+## Design for common use cases
 
 For APIs that syndicate data, consider several common client use cases:
 
@@ -19,25 +19,25 @@ For APIs that syndicate data, consider several common client use cases:
 * **Staying up to date.** Especially for large datasets, clients may want to keep their copy of the dataset up to date without downloading the entire dataset after every change. If this is a use case for the API, prioritize it in the design.
 * **Driving expensive actions.** What would happen if a client wanted to automatically send text messages to thousands of people or light up the side of a skyscraper every time a new record appears? Consider whether the API's records will always be in a reliable unchanging order, and whether they tend to appear in clumps or in a steady stream. Generally speaking, consider the "entropy" an API client would experience.
 
-### Using one's own API
+## Using one's own API
 
 The #1 best way to understand and address the weaknesses in an API's design and implementation is to use it in a production system.
 
 Whenever feasible, design an API in parallel with an accompanying integration of that API.
 
-### Point of contact
+## Point of contact
 
 Have an obvious mechanism for clients to report issues and ask questions about the API.
 
 When using GitHub for an API's code, use the associated issue tracker. In addition, publish an email address for direct, non-public inquiries.
 
-### Notifications of updates
+## Notifications of updates
 
 Have a simple mechanism for clients to follow changes to the API.
 
 Common ways to do this include a mailing list, or a [dedicated developer blog](https://developer.github.com/changes/) with an RSS feed.
 
-### API endpoints
+## API endpoints
 
 An "endpoint" is a combination of two things:
 
@@ -64,7 +64,7 @@ Some examples of these principles in action:
 * [OpenFDA example query](https://open.fda.gov/api/reference/#example-query)
 * [Sunlight Congress API methods](https://sunlightlabs.github.io/congress/#using-the-api)
 
-### Just use JSON
+## Just use JSON
 
 [JSON](https://en.wikipedia.org/wiki/JSON) is an excellent, widely supported transport format, suitable for many web APIs.
 
@@ -76,7 +76,7 @@ General JSON guidelines:
 * **Don't use unpredictable keys**. Parsing a JSON response where keys are unpredictable (e.g. derived from data) is difficult, and adds friction for clients.
 * **Use consistent case for keys**. Whether you use `under_score` or `CamelCase` for your API keys, make sure you are consistent.
 
-### Use a consistent date format
+## Use a consistent date format
 
 And specifically, [use ISO 8601](https://xkcd.com/1179/), in UTC.
 
@@ -85,7 +85,7 @@ For just dates, that looks like `2013-02-27`. For full times, that's of the form
 This date format is used all over the web, and puts each field in consistent order -- from least granular to most granular.
 
 
-### API keys
+## API keys
 
 These standards do not take a position on whether or not to use API keys.
 
@@ -96,7 +96,7 @@ This allows newcomers to use and experiment with the API in demo environments an
 Consider whether one of your product goals is to allow a certain level of normal production use of the API without enforcing advanced registration by clients.
 
 
-### Error handling
+## Error handling
 
 Handle all errors (including otherwise uncaught exceptions) and return a data structure in the same format as the rest of the API.
 
@@ -112,11 +112,11 @@ For example, a JSON API might provide the following when an uncaught exception o
 HTTP responses with error details should use a `4XX` status code to indicate a client-side failure (such as invalid authorization, or an invalid parameter), and a `5XX` status code to indicate server-side failure (such as an uncaught exception).
 
 
-### Pagination
+## Pagination
 
 If pagination is required to navigate datasets, use the method that makes the most sense for the API's data.
 
-#### Parameters
+### Parameters
 
 Common patterns:
 
@@ -124,7 +124,7 @@ Common patterns:
 * `offset` and `limit`. This standard comes from the SQL database world, and is a good option when you need stable permalinks to result sets.
 * `since` and `limit`. Get everything "since" some ID or timestamp. Useful when it's a priority to let clients efficiently stay "in sync" with data. Generally requires result set order to be very stable.
 
-#### Metadata
+### Metadata
 
 Include enough metadata so that clients can calculate how much data there is, and how and whether to fetch the next set of results.
 
@@ -141,7 +141,7 @@ Example of how that might be implemented:
 }
 ```
 
-### Always use HTTPS
+## Always use HTTPS
 
 Any new API should use and require [HTTPS encryption](https://en.wikipedia.org/wiki/HTTP_Secure). HTTPS provides:
 
@@ -155,7 +155,7 @@ The CIO Council provides two relevant guides:
 * **[Technical Guidelines](https://https.cio.gov/technical-guidelines/)** covering how your HTTPS should be configured.
 * **[Migrating APIs to HTTPS](https://https.cio.gov/apis/)** covering moving existing HTTP-only APIs to HTTPS.
 
-### Use UTF-8
+## Use UTF-8
 
 Just [use UTF-8](http://utf8everywhere.org).
 
@@ -169,7 +169,7 @@ An API that returns JSON should use:
 Content-Type: application/json; charset=utf-8
 ```
 
-### CORS
+## CORS
 
 For clients to be able to use an API from inside web browsers, the API must [enable CORS](http://enable-cors.org).
 

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -4,12 +4,6 @@ sidenav: approach
 sticky_sidenav: true
 ---
 
-# 18F API Standards
-
-**[18F](https://18f.gsa.gov/)** is a technology team inside the US federal government. 18F is very API-focused: our first project was an [API for business opportunities](https://fbopen.gsa.gov/).
-
-This document captures **18F's view of API best practices and standards**. We aim to incorporate as many of them as possible into our work.
-
 APIs, like other web applications, vary greatly in implementation and design, depending on the situation and the problem the application is solving.
 
 This document provides a mix of:
@@ -209,15 +203,3 @@ For more advanced configuration, see the [W3C spec](http://www.w3.org/TR/cors/) 
 **What about JSONP?**
 
 JSONP is [not secure or performant](https://gist.github.com/tmcw/6244497). If IE8 or IE9 must be supported, use Microsoft's [XDomainRequest](http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx?Redirected=true) object instead of JSONP. There are [libraries](https://github.com/mapbox/corslite) to help with this.
-
-
-## Public domain
-
-This project is in the public domain within the United States, and
-copyright and related rights in the work worldwide are waived through
-the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
-
-All contributions to this project will be released under the CC0
-dedication. By submitting a pull request, you are agreeing to comply
-with this waiver of copyright interest.
-

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -81,15 +81,13 @@ The CIO Council provides two relevant guides:
 
 {% include components/tag-requirement.html %} Just [use UTF-8](http://utf8everywhere.org).
 
-Expect accented characters or "smart quotes" in API output, even if they're not expected.
-
-An API should tell clients to expect UTF-8 by including a charset notation in the `Content-Type` header for responses.
-
-An API that returns JSON should use:
+An API should tell clients to expect UTF-8 by including a charset notation in the `Content-Type` header for responses. For example, an API that returns JSON should use:
 
 ```
 Content-Type: application/json; charset=utf-8
 ```
+
+Even if you do not believe your API will ever return data outside the ASCII character set, you should assume it could and return data encoded as UTF-8.
 
 ## Just use JSON 
 
@@ -99,15 +97,15 @@ Supporting JSON and only JSON is a practical default for APIs, and generally red
 
 General JSON guidelines:
 
-* Responses should be **a JSON object** (not an array). Using an array to return results limits the ability to include metadata about results, and limits the API's ability to add additional top-level keys in the future.
+* **Responses should be a JSON object (not an array)**. Using an array to return results limits the ability to include metadata about results, and limits the API's ability to add additional top-level keys in the future.
 * **Don't use unpredictable keys**. Parsing a JSON response where keys are unpredictable (e.g. derived from data) is difficult, and adds friction for clients.
 * **Use consistent case for keys**. Whether you use `under_score` or `CamelCase` for your API keys, make sure you are consistent.
 
 ## Use a consistent date format
 
-{% include components/tag-standard.html %} And specifically, [use ISO 8601](https://xkcd.com/1179/), in UTC.
+{% include components/tag-standard.html %} Specifically, [use ISO 8601](https://xkcd.com/1179/), in UTC.
 
-For just dates, that looks like `{{ site.time | date: '%Y-%m-%d' }}`. For full times, that's of the form 
+For dates, that looks like `{{ site.time | date: '%Y-%m-%d' }}`. For dates with times, that's of the form 
 `{{ site.time | date: '%Y-%m-%dT%TZ' }}`.
 
 This date format is used all over the web, and puts each field in consistent order -- from least granular to most granular.
@@ -130,7 +128,7 @@ For more advanced configuration, see the [W3C spec](http://www.w3.org/TR/cors/) 
 
 If keys are used to manage and authenticate API access, the API should allow some sort of unauthenticated access, without keys.
 
-This allows newcomers to use and experiment with the API in demo environments and with simple `curl`/`wget`/etc. requests.
+This allows newcomers to use and experiment with the API in demo environments and with simple `curl` / `wget` / etc. requests.
 
 Consider whether one of your product goals is to allow a certain level of normal production use of the API without enforcing advanced registration by clients.
 
@@ -177,5 +175,3 @@ For example, a JSON API might provide the following when an uncaught exception o
 ```
 
 HTTP responses with error details should use a `4XX` status code to indicate a client-side failure (such as invalid authorization, or an invalid parameter), and a `5XX` status code to indicate server-side failure (such as an uncaught exception).
-
-

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -64,7 +64,57 @@ Some examples of these principles in action:
 * [OpenFDA example query](https://open.fda.gov/api/reference/#example-query)
 * [Sunlight Congress API methods](https://sunlightlabs.github.io/congress/#using-the-api)
 
-## Just use JSON
+## Always use HTTPS
+
+Any new API should use and require [HTTPS encryption](https://en.wikipedia.org/wiki/HTTP_Secure). HTTPS provides:
+
+* **Security**. The contents of the request are encrypted across the Internet.
+* **Authenticity**. A stronger guarantee that a client is communicating with the real API.
+* **Privacy**. Enhanced privacy for apps and users using the API. HTTP headers and query string parameters (among other things) will be encrypted.
+* **Compatibility**. Broader client-side compatibility. For CORS requests to the API to work on HTTPS websites -- to not be blocked as mixed content -- those requests must be over HTTPS.
+
+The CIO Council provides two relevant guides:
+
+* **[Technical Guidelines](https://https.cio.gov/technical-guidelines/)** covering how your HTTPS should be configured.
+* **[Migrating APIs to HTTPS](https://https.cio.gov/apis/)** covering moving existing HTTP-only APIs to HTTPS.
+
+## CORS
+
+For clients to be able to use an API from inside web browsers, the API must [enable CORS](http://enable-cors.org).
+
+For the simplest and most common use case, where the entire API should be accessible from inside the browser, enabling CORS is as simple as including this HTTP header in all responses:
+
+```
+Access-Control-Allow-Origin: *
+```
+
+It's supported by [every modern browser](http://enable-cors.org/client.html).
+
+For more advanced configuration, see the [W3C spec](http://www.w3.org/TR/cors/) or [Mozilla's guide](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).
+
+## API keys
+
+If keys are used to manage and authenticate API access, the API should allow some sort of unauthenticated access, without keys.
+
+This allows newcomers to use and experiment with the API in demo environments and with simple `curl`/`wget`/etc. requests.
+
+Consider whether one of your product goals is to allow a certain level of normal production use of the API without enforcing advanced registration by clients.
+
+## Use UTF-8
+
+Just [use UTF-8](http://utf8everywhere.org).
+
+Expect accented characters or "smart quotes" in API output, even if they're not expected.
+
+An API should tell clients to expect UTF-8 by including a charset notation in the `Content-Type` header for responses.
+
+An API that returns JSON should use:
+
+```
+Content-Type: application/json; charset=utf-8
+```
+
+## Just use JSON 
 
 [JSON](https://en.wikipedia.org/wiki/JSON) is an excellent, widely supported transport format, suitable for many web APIs.
 
@@ -84,32 +134,6 @@ For just dates, that looks like `2013-02-27`. For full times, that's of the form
 
 This date format is used all over the web, and puts each field in consistent order -- from least granular to most granular.
 
-
-## API keys
-
-These standards do not take a position on whether or not to use API keys.
-
-But _if_ keys are used to manage and authenticate API access, the API should allow some sort of unauthenticated access, without keys.
-
-This allows newcomers to use and experiment with the API in demo environments and with simple `curl`/`wget`/etc. requests.
-
-Consider whether one of your product goals is to allow a certain level of normal production use of the API without enforcing advanced registration by clients.
-
-
-## Error handling
-
-Handle all errors (including otherwise uncaught exceptions) and return a data structure in the same format as the rest of the API.
-
-For example, a JSON API might provide the following when an uncaught exception occurs:
-
-```json
-{
-  "message": "Description of the error.",
-  "exception": "[detailed stacktrace]"
-}
-```
-
-HTTP responses with error details should use a `4XX` status code to indicate a client-side failure (such as invalid authorization, or an invalid parameter), and a `5XX` status code to indicate server-side failure (such as an uncaught exception).
 
 
 ## Pagination
@@ -141,44 +165,19 @@ Example of how that might be implemented:
 }
 ```
 
-## Always use HTTPS
+## Error handling
 
-Any new API should use and require [HTTPS encryption](https://en.wikipedia.org/wiki/HTTP_Secure). HTTPS provides:
+Handle all errors (including otherwise uncaught exceptions) and return a data structure in the same format as the rest of the API.
 
-* **Security**. The contents of the request are encrypted across the Internet.
-* **Authenticity**. A stronger guarantee that a client is communicating with the real API.
-* **Privacy**. Enhanced privacy for apps and users using the API. HTTP headers and query string parameters (among other things) will be encrypted.
-* **Compatibility**. Broader client-side compatibility. For CORS requests to the API to work on HTTPS websites -- to not be blocked as mixed content -- those requests must be over HTTPS.
+For example, a JSON API might provide the following when an uncaught exception occurs:
 
-The CIO Council provides two relevant guides:
-
-* **[Technical Guidelines](https://https.cio.gov/technical-guidelines/)** covering how your HTTPS should be configured.
-* **[Migrating APIs to HTTPS](https://https.cio.gov/apis/)** covering moving existing HTTP-only APIs to HTTPS.
-
-## Use UTF-8
-
-Just [use UTF-8](http://utf8everywhere.org).
-
-Expect accented characters or "smart quotes" in API output, even if they're not expected.
-
-An API should tell clients to expect UTF-8 by including a charset notation in the `Content-Type` header for responses.
-
-An API that returns JSON should use:
-
-```
-Content-Type: application/json; charset=utf-8
+```json
+{
+  "message": "Description of the error.",
+  "exception": "[detailed stacktrace]"
+}
 ```
 
-## CORS
+HTTP responses with error details should use a `4XX` status code to indicate a client-side failure (such as invalid authorization, or an invalid parameter), and a `5XX` status code to indicate server-side failure (such as an uncaught exception).
 
-For clients to be able to use an API from inside web browsers, the API must [enable CORS](http://enable-cors.org).
 
-For the simplest and most common use case, where the entire API should be accessible from inside the browser, enabling CORS is as simple as including this HTTP header in all responses:
-
-```
-Access-Control-Allow-Origin: *
-```
-
-It's supported by [every modern browser](http://enable-cors.org/client.html).
-
-For more advanced configuration, see the [W3C spec](http://www.w3.org/TR/cors/) or [Mozilla's guide](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -77,28 +77,6 @@ The CIO Council provides two relevant guides:
 * **[Technical Guidelines](https://https.cio.gov/technical-guidelines/)** covering how your HTTPS should be configured.
 * **[Migrating APIs to HTTPS](https://https.cio.gov/apis/)** covering moving existing HTTP-only APIs to HTTPS.
 
-## CORS
-
-For clients to be able to use an API from inside web browsers, the API must [enable CORS](http://enable-cors.org).
-
-For the simplest and most common use case, where the entire API should be accessible from inside the browser, enabling CORS is as simple as including this HTTP header in all responses:
-
-```
-Access-Control-Allow-Origin: *
-```
-
-It's supported by [every modern browser](http://enable-cors.org/client.html).
-
-For more advanced configuration, see the [W3C spec](http://www.w3.org/TR/cors/) or [Mozilla's guide](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).
-
-## API keys
-
-If keys are used to manage and authenticate API access, the API should allow some sort of unauthenticated access, without keys.
-
-This allows newcomers to use and experiment with the API in demo environments and with simple `curl`/`wget`/etc. requests.
-
-Consider whether one of your product goals is to allow a certain level of normal production use of the API without enforcing advanced registration by clients.
-
 ## Use UTF-8
 
 Just [use UTF-8](http://utf8everywhere.org).
@@ -133,7 +111,27 @@ For just dates, that looks like `2013-02-27`. For full times, that's of the form
 
 This date format is used all over the web, and puts each field in consistent order -- from least granular to most granular.
 
+## CORS
 
+For clients to be able to use an API from inside web browsers, the API must [enable CORS](http://enable-cors.org).
+
+For the simplest and most common use case, where the entire API should be accessible from inside the browser, enabling CORS is as simple as including this HTTP header in all responses:
+
+```
+Access-Control-Allow-Origin: *
+```
+
+It's supported by [every modern browser](http://enable-cors.org/client.html).
+
+For more advanced configuration, see the [W3C spec](http://www.w3.org/TR/cors/) or [Mozilla's guide](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).
+
+## API keys
+
+If keys are used to manage and authenticate API access, the API should allow some sort of unauthenticated access, without keys.
+
+This allows newcomers to use and experiment with the API in demo environments and with simple `curl`/`wget`/etc. requests.
+
+Consider whether one of your product goals is to allow a certain level of normal production use of the API without enforcing advanced registration by clients.
 
 ## Pagination
 

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -179,10 +179,6 @@ For the simplest and most common use case, where the entire API should be access
 Access-Control-Allow-Origin: *
 ```
 
-It's supported by [every modern browser](http://enable-cors.org/client.html), and will Just Work in many JavaScript clients, like [jQuery](https://jquery.com).
+It's supported by [every modern browser](http://enable-cors.org/client.html).
 
 For more advanced configuration, see the [W3C spec](http://www.w3.org/TR/cors/) or [Mozilla's guide](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).
-
-**What about JSONP?**
-
-JSONP is [not secure or performant](https://gist.github.com/tmcw/6244497). If IE8 or IE9 must be supported, use Microsoft's [XDomainRequest](http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx?Redirected=true) object instead of JSONP. There are [libraries](https://github.com/mapbox/corslite) to help with this.

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -48,6 +48,7 @@ Information can be passed to an endpoint in either of two ways:
 
 * The URL query string (e.g. `?year=2014`)
 * HTTP headers (e.g. `X-Api-Key: my-key`)
+* The HTTP request body (for `POST` and `PUT` requests)
 
 When people say "RESTful" nowadays, they really mean designing simple, intuitive endpoints that represent unique functions in the API.
 

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -143,35 +143,17 @@ Example of how that might be implemented:
 
 ### Always use HTTPS
 
-Any new API should use and require [HTTPS encryption](https://en.wikipedia.org/wiki/HTTP_Secure) (using TLS/SSL). HTTPS provides:
+Any new API should use and require [HTTPS encryption](https://en.wikipedia.org/wiki/HTTP_Secure). HTTPS provides:
 
 * **Security**. The contents of the request are encrypted across the Internet.
 * **Authenticity**. A stronger guarantee that a client is communicating with the real API.
 * **Privacy**. Enhanced privacy for apps and users using the API. HTTP headers and query string parameters (among other things) will be encrypted.
 * **Compatibility**. Broader client-side compatibility. For CORS requests to the API to work on HTTPS websites -- to not be blocked as mixed content -- those requests must be over HTTPS.
 
-HTTPS should be configured using modern best practices, including ciphers that support [forward secrecy](https://en.wikipedia.org/wiki/Forward_secrecy), and [HTTP Strict Transport Security](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security). **This is not exhaustive**: use tools like [SSL Labs](https://www.ssllabs.com/ssltest/analyze.html) to evaluate an API's HTTPS configuration.
+The CIO Council provides two relevant guides:
 
-For an existing API that runs over plain HTTP, the first step is to add HTTPS support, and update the documentation to declare it the default, use it in examples, etc.
-
-Then, evaluate the viability of disabling or redirecting plain HTTP requests. See [GSA/api.data.gov#34](https://github.com/18F/api.data.gov/issues/34) for a discussion of some of the issues involved with transitioning from HTTP->HTTPS.
-
-#### Server Name Indication
-
-If you can, use [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication) (SNI) to serve HTTPS requests.
-
-SNI is an extension to TLS, [first proposed in 2003](http://tools.ietf.org/html/rfc3546), that allows SSL certificates for multiple domains to be served from a single IP address.
-
-Using one IP address to host multiple HTTPS-enabled domains can significantly lower costs and complexity in server hosting and administration. This is especially true as IPv4 addresses become more rare and costly. SNI is a Good Idea, and it is widely supported.
-
-However, some clients and networks still do not properly support SNI. As of this writing, that includes:
-
-* Internet Explorer 8 and below on Windows XP
-* Android 2.3 (Gingerbread) and below.
-* All versions of Python 2.x (a version of Python 2.x with SNI [is planned](http://legacy.python.org/dev/peps/pep-0466/)).
-* Some enterprise network environments have been configured in some custom way that disables or interferes with SNI support. One identified network where this is the case: the White House.
-
-When implementing SSL support for an API, evaluate whether SNI support makes sense for the audience it serves.
+* **[Technical Guidelines](https://https.cio.gov/technical-guidelines/)** covering how your HTTPS should be configured.
+* **[Migrating APIs to HTTPS](https://https.cio.gov/apis/)** covering moving existing HTTP-only APIs to HTTPS.
 
 ### Use UTF-8
 

--- a/_pages/apis.md
+++ b/_pages/apis.md
@@ -60,8 +60,7 @@ Generally speaking:
 
 Some examples of these principles in action:
 
-* [FBOpen API documentation](https://18f.github.io/fbopen/)
-* [OpenFDA example query](https://open.fda.gov/api/reference/#example-query)
+* [OpenFEC API](https://api.open.fec.gov/developers/)
 * [Sunlight Congress API methods](https://sunlightlabs.github.io/congress/#using-the-api)
 
 ## Always use HTTPS


### PR DESCRIPTION
This PR brings in the now-archived [18F API Standards](https://github.com/18F/api-standards) repo into the guide. The new page, called **APIs**, is (for now) in the _Our Approach_ section.

Things I'd like to do before landing:

- [x] Find some good example links for APIs demonstrating these practices
- [x] Incorporate our classification system (`SUGGESTION`, `REQUIREMENT`, etc.)

Closes #295