### PR TITLE
add email address and privacy policy

### DIFF
--- a/_data/usa_identifier.yml
+++ b/_data/usa_identifier.yml
@@ -28,3 +28,4 @@ accessibility_url: "https://www.gsa.gov/website-information/accessibility-aids"
 usagov_contact_url: "https://www.usa.gov/contact"
 edit_page:
     - text: "Edit this page"
+privacy_policy_url: "https://www.gsa.gov/website-information/website-policies"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,6 +13,19 @@
 <footer class="identifier" data-uswds="1.0">
 {% if identifier.edit_page or (identifier.last_updated and page.last_modified_at) %}
   {% unless footer.type %}
+    <div class="usa-footer__secondary-section">
+      <div class="grid-container">
+        <div class="grid-row grid-gap">
+          <div class="usa-footer__contact-links mobile-lg:grid-col-12">
+            <div class="usa-footer grid-row grid-gap-1">
+              <div class="grid-col-auto">
+                Have questions or would like to contact us? Email us at <a class="usa-link" href="mailto:{{ identifier.site_email }}">{{ identifier.site_email }}</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
     <div class="component-identifier-meta">
       <div class="grid-container grid-container-desktop">
         <div class="grid-row tablet-lg:grid-gap-2">
@@ -82,6 +95,11 @@
         <li class="usa-identifier__required-links-item">
           <a class="usa-identifier__required-link usa-link" href="{{ identifier.no_fear_act_url }}" title="View No FEAR Act data">
             View No FEAR Act data
+          </a>
+        </li>
+        <li class="usa-identifier__required-links-item">
+          <a class="usa-identifier__required-link usa-link" href="{{ identifier.privacy_policy_url }}" title="View privacy policy">
+            Privacy policy
           </a>
         </li>
       </ul>


### PR DESCRIPTION
As per [digital council needs](https://gsa-tts.slack.com/archives/C018QJ2L44X/p1655234447293049), the engineering development guide should have:
* A way for someone to contact [via email](https://gsa-tts.slack.com/archives/C02UQQWDSR1/p1655316684335769?thread_ts=1655308177.072209&cid=C02UQQWDSR1) and 
* A link to the privacy policy,