### PR TITLE
Change secondary org to 18F in identifier (footer region).

### DIFF
--- a/_data/usa_identifier.yml
+++ b/_data/usa_identifier.yml
@@ -13,8 +13,8 @@ org_primary_url: https://www.gsa.gov/tts/
 org_primary_email: tts-info@gsa.gov
 org_primary_about: https://www.gsa.gov/tts/
 org_primary_bio: "As part of GSA’s Technology Transformation Services (TTS), we apply modern methodologies and technologies to improve the public’s experience with government. We help agencies make their services more accessible, efficient, and effective with modern applications, platforms, processes, personnel, and software solutions."
-org_secondary: Technology Transformation Services
-org_secondary_acronym: TTS
+org_secondary: 18F
+org_secondary_acronym: 18F
 org_secondary_logo: 18f-logo-blue.svg
 org_secondary_url: https://18f.gsa.gov
 org_secondary_email: 18F@gsa.gov


### PR DESCRIPTION
### What's wrong?
👋🏾 Hi. I'm working on the 18F Guides and Methods. We noticed the Engineering Guide identifier says "This project is maintained by Technology Transformation Services" but the link points to [18F](https://18f.gsa.gov/). The other guides say "This project is maintained by [18F](https://18f.gsa.gov/)".

![image](https://user-images.githubusercontent.com/381122/186579964-57da2471-a5e3-4406-855c-6273f7154902.png)


### What am I proposing?
Change the secondary org to 18F in the yml file. The primary org is still TTS.

![image](https://user-images.githubusercontent.com/381122/186580123-cd9f4457-3201-4149-9e26-ee99841c1cb4.png)

### Federalist preview:
https://federalist-0fc100fe-c4d0-4b8f-bd4f-7392edd7c16d.app.cloud.gov/preview/18f/development-guide/cannandev-maintained-by-18F-identifier-org/
